### PR TITLE
Pass token in from the blueprint backend.

### DIFF
--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -142,6 +142,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             auto_refresh_kwargs=self.auto_refresh_kwargs,
             scope=self.scope,
             state=self.state,
+            token=self.token,
             blueprint=self,
             base_url=self.base_url,
             **self.kwargs


### PR DESCRIPTION
The quickstart examples are failing because the OAuth2Session authorized method is always returning False. I tracked it down and it turns out that the token isn't being loaded from the blueprint backend. I'm not sure if this is the best way to fix this, but it works for me.