### PR TITLE
Make the `authorized` property load the token from the backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+unreleased
+----------
+* Make the ``authorized`` property on both ``OAuth1Session`` and ``OAuth2Session``
+  dynamically load the token from the backend
+
 0.5.0 (2015-04-20)
 ------------------
 * Redesigned token storage backend system: it now uses objects

--- a/flask_dance/consumer/__init__.py
+++ b/flask_dance/consumer/__init__.py
@@ -1,4 +1,4 @@
 from .oauth1 import OAuth1ConsumerBlueprint
 from .oauth2 import OAuth2ConsumerBlueprint
 from .base import oauth_authorized, oauth_error
-
+from .requests import OAuth1Session, OAuth2Session

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -25,19 +25,28 @@ class OAuth1Session(BaseOAuth1Session):
     def token(self):
         return self.blueprint.token
 
-    def prepare_request(self, request):
-        if self.base_url:
-            request.url = self.base_url.relative(request.url)
-        return super(OAuth1Session, self).prepare_request(request)
-
-    def request(self, method, url, data=None, headers=None, **kwargs):
+    def load_token(self):
         t = self.token
         if t and "oauth_token" in t and "oauth_token_secret" in t:
             # This really, really violates the Law of Demeter, but
             # I don't see a better way to set these parameters. :(
             self.auth.client.resource_owner_key = to_unicode(t["oauth_token"])
             self.auth.client.resource_owner_secret = to_unicode(t["oauth_token_secret"])
+            return True
+        return False
 
+    @property
+    def authorized(self):
+        self.load_token()
+        return super(OAuth1Session, self).authorized
+
+    def prepare_request(self, request):
+        if self.base_url:
+            request.url = self.base_url.relative(request.url)
+        return super(OAuth1Session, self).prepare_request(request)
+
+    def request(self, method, url, data=None, headers=None, **kwargs):
+        self.load_token()
         return super(OAuth1Session, self).request(
             method=method, url=url, data=data, headers=headers, **kwargs
         )
@@ -62,14 +71,23 @@ class OAuth2Session(BaseOAuth2Session):
     def token(self):
         return self.blueprint.token
 
+    def load_token(self):
+        self._client.token = self.token
+        if self.token:
+            self._client._populate_attributes(self.token)
+            return True
+        return False
+
+    @property
+    def authorized(self):
+        self.load_token()
+        return super(OAuth2Session, self).authorized
+
     def request(self, method, url, data=None, headers=None, **kwargs):
         if self.base_url:
             url = self.base_url.relative(url)
 
-        self._client.token = self.token
-        if self.token:
-            self._client._populate_attributes(self.token)
-
+        self.load_token()
         return super(OAuth2Session, self).request(
             method=method, url=url, data=data, headers=headers, **kwargs
         )

--- a/tests/consumer/test_requests.py
+++ b/tests/consumer/test_requests.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+import mock
+from distutils.version import StrictVersion
+import requests_oauthlib
+from flask_dance.consumer.requests import OAuth1Session, OAuth2Session
+
+requires_requests_oauthlib_043 = pytest.mark.skipif(
+    StrictVersion(requests_oauthlib.__version__) < StrictVersion('0.4.3'),
+    reason="requires requests_oauthlib at version 0.4.3 or higher",
+)
+
+
+FAKE_OAUTH1_TOKEN = {
+    "oauth_token": "abcdefg",
+    "oauth_token_secret": "hijklmnop",
+}
+FAKE_OAUTH2_TOKEN = {
+    "access_token": "deadbeef",
+    "scope": ["custom"],
+    "token_type": "bearer",
+}
+
+
+@requires_requests_oauthlib_043
+def test_oauth1session_authorized():
+    bp = mock.Mock(token=FAKE_OAUTH1_TOKEN)
+    sess = OAuth1Session(client_key="ckey", client_secret="csec", blueprint=bp)
+    assert sess.authorized == True
+
+
+@requires_requests_oauthlib_043
+def test_oauth1session_not_authorized():
+    bp = mock.Mock(token=None)
+    sess = OAuth1Session(client_key="ckey", client_secret="csec", blueprint=bp)
+    assert sess.authorized == False
+
+
+def test_oauth2session_authorized():
+    bp = mock.Mock(token=FAKE_OAUTH2_TOKEN)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.authorized == True
+
+
+def test_oauth2session_not_authorized():
+    bp = mock.Mock(token=None)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.authorized == False


### PR DESCRIPTION
To properly fix the bug identified in #12. Unfortunately, the `OAuth1Session` tests fail on the current version of requests-oauthlib (0.4.2), because it still contains the bug fixed by https://github.com/requests/requests-oauthlib/commit/b94f16472d66f5ed0febb8c1985854f379f7bac3.