### PR TITLE
Bubble up the params that caused a MissingTokenError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ unreleased
 * Added the Meetup pre-set configuration
 * Flask-Dance now always passes the optional ``redirect_uri`` parameter to
   the OAuth 2 authorization request, since Dropbox requires it.
+* Make Flask-Dance provide additional information in errors when providers fail
+  to provide auth tokens
 
 0.5.1 (2015-04-28)
 ------------------


### PR DESCRIPTION
When experimenting with Facebook I became frustrated because I misconfigured my app
![screen shot 2015-05-06 at 12 39 41 am](https://cloud.githubusercontent.com/assets/1521093/7487587/8eec5cca-f388-11e4-9493-89a7b2e4a4b3.png)

Had I been observant I would have noticed the error message in the URL. But I was looking at flasks debug message which was useless. So I ended up digging into the source. Not to mention I am not fluent in URL encoding

To prevent me or others from needing to do this again I wrapped the error up in a way that displays in the browser stack trace

![screen shot 2015-05-06 at 7 30 09 pm](https://cloud.githubusercontent.com/assets/1521093/7505933/98cd40f8-f426-11e4-9e67-0cf2685e3929.png)

I addressed the comments and obvious sloppiness from the previous PR. Specifically the test should work with any complaint python interpreter and I modify and reraise the original exception rather than making a new one

*im assuming that you still want python 2 support so I did not use exception chaining*

