### PR TITLE
add facebook provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ unreleased
 ----------
 * Added the Dropbox pre-set configuration
 * Added the Meetup pre-set configuration
+* Added the Facebook pre-set configuration
 * Flask-Dance now always passes the optional ``redirect_uri`` parameter to
   the OAuth 2 authorization request, since Dropbox requires it.
 * Make Flask-Dance provide additional information in errors when providers fail

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -11,6 +11,18 @@ to Flask-Dance!
    :local:
    :backlinks: none
 
+Facebook
+--------
+.. module:: flask_dance.contrib.facebook
+
+.. autofunction:: make_facebook_blueprint
+
+.. data:: facebook
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the Facebook authentication token loaded (assuming that the user
+    has authenticated with Facebook at some point in the past).
+
 GitHub
 ------
 .. module:: flask_dance.contrib.github

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -1,0 +1,72 @@
+from __future__ import unicode_literals
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from functools import partial
+from flask.globals import LocalProxy, _lookup_app_object
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+
+
+__maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
+
+
+def make_facebook_blueprint(
+        client_id=None, client_secret=None, scope=None, redirect_url=None,
+        redirect_to=None, login_url=None, authorized_url=None,
+        session_class=None, backend=None):
+    """
+    Make a blueprint for authenticating with Facebook using OAuth 2. This requires
+    a client ID and client secret from Facebook. You should either pass them to
+    this constructor, or make sure that your Flask application config defines
+    them, using the variables FACEBOOK_OAUTH_CLIENT_ID and FACEBOOK_OAUTH_CLIENT_SECRET.
+
+    Args:
+        client_id (str): The client ID for your application on Facebook.
+        client_secret (str): The client secret for your application on Facebook
+        scope (str, optional): comma-separated list of scopes for the OAuth token
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/facebook``
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/facebook/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        backend: A storage backend class, or an instance of a storage
+                backend class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+    facebook_bp = OAuth2ConsumerBlueprint("facebook", __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url="https://graph.facebook.com/",
+        authorization_url="https://www.facebook.com/dialog/oauth",
+        token_url="https://graph.facebook.com/oauth/access_token",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        session_class=session_class,
+        backend=backend,
+    )
+    facebook_bp.from_config["client_id"] = "FACEBOOK_OAUTH_CLIENT_ID"
+    facebook_bp.from_config["client_secret"] = "FACEBOOK_OAUTH_CLIENT_SECRET"
+
+    @facebook_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.facebook_oauth = facebook_bp.session
+
+    return facebook_bp
+
+facebook = LocalProxy(partial(_lookup_app_object, "facebook_oauth"))

--- a/tests/contrib/test_facebook.py
+++ b/tests/contrib/test_facebook.py
@@ -1,0 +1,78 @@
+from __future__ import unicode_literals
+
+import pytest
+import responses
+from urlobject import URLObject
+from flask import Flask
+from flask_dance.contrib.facebook import make_facebook_blueprint, facebook
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.consumer.backend import MemoryBackend
+
+
+def test_blueprint_factory():
+    facebook_bp = make_facebook_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="user:email",
+        redirect_to="index",
+    )
+    assert isinstance(facebook_bp, OAuth2ConsumerBlueprint)
+    assert facebook_bp.session.scope == "user:email"
+    assert facebook_bp.session.base_url == "https://graph.facebook.com/"
+    assert facebook_bp.session.client_id == "foo"
+    assert facebook_bp.client_secret == "bar"
+    assert facebook_bp.authorization_url == "https://www.facebook.com/dialog/oauth"
+    assert facebook_bp.token_url == "https://graph.facebook.com/oauth/access_token"
+
+
+def test_load_from_config():
+    app = Flask(__name__)
+    app.secret_key = "anything"
+    app.config["FACEBOOK_OAUTH_CLIENT_ID"] = "foo"
+    app.config["FACEBOOK_OAUTH_CLIENT_SECRET"] = "bar"
+    facebook_bp = make_facebook_blueprint(redirect_to="index")
+    app.register_blueprint(facebook_bp)
+
+    resp = app.test_client().get("/facebook")
+    url = resp.headers["Location"]
+    client_id = URLObject(url).query.dict.get("client_id")
+    assert client_id == "foo"
+
+
+@responses.activate
+def test_context_local():
+    responses.add(responses.GET, "https://google.com")
+
+    # set up two apps with two different set of auth tokens
+    app1 = Flask(__name__)
+    fbbp1 = make_facebook_blueprint(
+        "foo1", "bar1", redirect_to="url1",
+        backend=MemoryBackend({"access_token": "app1"}),
+    )
+    app1.register_blueprint(fbbp1)
+
+    app2 = Flask(__name__)
+    fbbp2 = make_facebook_blueprint(
+        "foo2", "bar2", redirect_to="url2",
+        backend=MemoryBackend({"access_token": "app2"}),
+    )
+    app2.register_blueprint(fbbp2)
+
+    # outside of a request context, referencing functions on the `facebook` object
+    # will raise an exception
+    with pytest.raises(RuntimeError):
+        facebook.get("https://google.com")
+
+    # inside of a request context, `facebook` should be a proxy to the correct
+    # blueprint session
+    with app1.test_request_context("/"):
+        app1.preprocess_request()
+        facebook.get("https://google.com")
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer app1"
+
+    with app2.test_request_context("/"):
+        app2.preprocess_request()
+        facebook.get("https://google.com")
+        request = responses.calls[1].request
+        assert request.headers["Authorization"] == "Bearer app2"


### PR DESCRIPTION
Facebook is super popular! Like, at least 10 people on it. 

They also provide OAUTH! So I followed the Github blueprint and made a Facebook one. 

Tests pass, ill let you pep8 it :-P

Here is the app I wrote to test it 

```python
from flask import Flask, redirect, url_for
from flask_dance.contrib.facebook import make_facebook_blueprint, facebook

app = Flask(__name__)
app.secret_key = "SOSECRET"
blueprint = make_facebook_blueprint(
    client_id="1386968274964921",
    client_secret="dae4975ded05aadbbda82f5ae9477d9d",
)
app.register_blueprint(blueprint, url_prefix="/login")


@app.route("/")
def index():
    if not facebook.authorized:
        return redirect(url_for("facebook.login"))
    resp = facebook.get("me")
    assert resp.ok
    return resp.text

if __name__ == "__main__":
    app.run()
```

and a screenshot of the output

![screen shot 2015-05-12 at 7 56 59 pm](https://cloud.githubusercontent.com/assets/1521093/7601295/391a973a-f8e2-11e4-9685-15583c210794.png)

