### PR TITLE
Added Bitbucket as a provider

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -11,6 +11,18 @@ to Flask-Dance!
    :local:
    :backlinks: none
 
+Bitbucket
+--------
+.. module:: flask_dance.contrib.bitbucket
+
+.. autofunction:: make_bitbucket_blueprint
+
+.. data:: bitbucket
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the Bitbucket authentication token loaded (assuming that the user
+    has authenticated with Bitbucket at some point in the past).
+
 Facebook
 --------
 .. module:: flask_dance.contrib.facebook

--- a/docs/quickstarts/index.rst
+++ b/docs/quickstarts/index.rst
@@ -7,6 +7,7 @@ Contents:
    :maxdepth: 1
 
    github
+   bitbucket
    google
    twitter
    dropbox

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -42,6 +42,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             redirect_to=None,
             session_class=None,
             backend=None,
+            auth=None,
 
             **kwargs):
         """
@@ -99,6 +100,9 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             backend: A storage backend class, or an instance of a storage
                 backend class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+            auth: Authentication details details to be passed on to `requests`. This
+                can be a tuple of (<username>, <password>) or any class that `requests`
+                allows.
         """
         BaseOAuthConsumerBlueprint.__init__(
             self, name, import_name,
@@ -124,6 +128,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         self.state = state
         self.kwargs = kwargs
         self.client_secret = client_secret
+        self.auth = auth
 
         # used by view functions
         self.authorization_url = authorization_url
@@ -208,6 +213,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
                 self.token_url,
                 authorization_response=url,
                 client_secret=self.client_secret,
+                auth=self.auth,
                 **self.token_url_params
             )
         except MissingCodeError as e:

--- a/flask_dance/contrib/bitbucket.py
+++ b/flask_dance/contrib/bitbucket.py
@@ -1,0 +1,74 @@
+from __future__ import unicode_literals
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from functools import partial
+from flask.globals import LocalProxy, _lookup_app_object
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+
+
+__maintainer__ = "Christian Lerrahn <github@penpal4u.net>"
+
+
+def make_bitbucket_blueprint(
+        client_id=None, client_secret=None, scope=None, redirect_url=None,
+        redirect_to=None, login_url=None, authorized_url=None,
+        session_class=None, backend=None, auth=None):
+    """
+    Make a blueprint for authenticating with Bitbucket using OAuth 2. This requires
+    a client ID and client secret from Bitbucket. You should either pass them to
+    this constructor, or make sure that your Flask application config defines
+    them, using the variables BITBUCKET_OAUTH_CLIENT_ID and BITBUCKET_OAUTH_CLIENT_SECRET.
+
+    Args:
+        client_id (str): The client ID for your application on Bitbucket.
+        client_secret (str): The client secret for your application on Bitbucket
+        scope (str, optional): comma-separated list of scopes for the OAuth token
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/bitbucket``
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/bitbucket/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        backend: A storage backend class, or an instance of a storage
+                backend class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+        auth: Authentication credentials to be used when fetching token.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+    bitbucket_bp = OAuth2ConsumerBlueprint("bitbucket", __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url="https://bitbucket.org/",
+        authorization_url="https://bitbucket.org/site/oauth2/authorize",
+        token_url="https://bitbucket.org/site/oauth2/access_token",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        session_class=session_class,
+        backend=backend,
+        auth=(client_id, client_secret),
+    )
+    bitbucket_bp.from_config["client_id"] = "BITBUCKET_OAUTH_CLIENT_ID"
+    bitbucket_bp.from_config["client_secret"] = "BITBUCKET_OAUTH_CLIENT_SECRET"
+
+    @bitbucket_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.bitbucket_oauth = bitbucket_bp.session
+
+    return bitbucket_bp
+
+bitbucket = LocalProxy(partial(_lookup_app_object, "bitbucket_oauth"))


### PR DESCRIPTION
Bitbucket requires HTTP Basic Authentication with client_id and client_secret when fetching tokens. `OAuth2ConsumerBlueprint` has been modified accordingly and a provider `Bitbucket` added.

Documentation updated accordingly.

Version number untouched.