### PR TITLE
Added Bitbucket provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ README will give you a taste of the features.
 Flask-Dance currently provides pre-set OAuth configurations for the following
 popular websites:
 
+* Bitbucket
 * Facebook
 * GitHub
 * Google

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -11,6 +11,18 @@ to Flask-Dance!
    :local:
    :backlinks: none
 
+Bitbucket
+--------
+.. module:: flask_dance.contrib.bitbucket
+
+.. autofunction:: make_bitbucket_blueprint
+
+.. data:: bitbucket
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the Bitbucket authentication token loaded (assuming that the user
+    has authenticated with Bitbucket at some point in the past).
+
 Facebook
 --------
 .. module:: flask_dance.contrib.facebook

--- a/docs/quickstarts/bitbucket.rst
+++ b/docs/quickstarts/bitbucket.rst
@@ -1,0 +1,84 @@
+Bitbucket Quickstart
+=================
+
+Setup Application
+-----------------
+Visit https://bitbucket.org/account/user/nothingbutweb/api
+to register an application on Bitbucket. The application's "authorization
+callback URL" must be ``http://localhost:5000/login/bitbucket/authorized``.
+Take note of the "Client ID" and "Client Secret" for the application.
+
+Code
+----
+.. code-block:: python
+
+    from flask import Flask, redirect, url_for
+    from flask_dance.contrib.bitbucket import make_bitbucket_blueprint, bitbucket
+
+    app = Flask(__name__)
+    app.secret_key = "supersekrit"
+    blueprint = make_bitbucket_blueprint(
+        client_id="my-key-here",
+        client_secret="my-secret-here",
+    )
+    app.register_blueprint(blueprint, url_prefix="/login")
+
+    @app.route("/")
+    def index():
+        if not bitbucket.authorized:
+            return redirect(url_for("bitbucket.login"))
+        resp = bitbucket.get("/api/1.0/user")
+        assert resp.ok
+        return "You are @{login} on Bitbucket".format(login=resp.json()["user"]["username"])
+
+    if __name__ == "__main__":
+        app.run()
+
+.. note::
+    You must replace ``my-key-here`` and ``my-secret-here`` with the client ID
+    and client secret that you got from your Bitbucket application.
+
+.. note::
+    If you are running this code on Heroku, you'll need to use the
+    :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
+
+When you run this code, you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT`
+environment variable for it to work. For example, if you put this code in a
+file named ``bitbucket.py``, you could run:
+
+.. code-block:: bash
+
+    $ export OAUTHLIB_INSECURE_TRANSPORT=1
+    $ python bitbucket.py
+
+Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+immediately.
+
+.. _localhost:5000: http://localhost:5000/
+
+.. warning::
+    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
+    this variable allows you to use insecure ``http`` for OAuth communication.
+    However, for security, all OAuth interactions must occur over secure
+    ``https`` when running in production.
+
+Explanation
+-----------
+This code makes a :ref:`blueprint <flask:blueprints>` that implements the views
+necessary to be a consumer in the :doc:`OAuth dance <../how-oauth-works>`. The
+blueprint has two views: ``/bitbucket``, which is the view that the user visits
+to begin the OAuth dance, and ``/bitbucket/authorized``, which is the view that
+the user is redirected to at the end of the OAuth dance. Because we set the
+``url_prefix`` to be ``/login``, the end result is that the views are at
+``/login/bitbucket`` and ``/login/bitbucket/authorized``. The second view is the
+"authorized callback URL" that you must tell Bitbucket about when you create
+the application.
+
+The ``bitbucket`` variable is a :class:`requests.Session` instance, which will be
+be preloaded with the user's access token once the user has gone through the
+OAuth dance. You can check the ``bitbucket.authorized`` boolean to determine if
+the access token is loaded. Whether the access token is loaded or not,
+you can use all the normal ``requests`` methods, like
+:meth:`~requests.Session.get` and :meth:`~requests.Session.post`,
+to make HTTP requests. If you only specify the path component of the URL,
+the domain will default to ``https://bitbucket.org/``.

--- a/docs/quickstarts/index.rst
+++ b/docs/quickstarts/index.rst
@@ -7,6 +7,7 @@ Contents:
    :maxdepth: 1
 
    github
+   bitbucket
    google
    twitter
    dropbox

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -42,6 +42,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             redirect_to=None,
             session_class=None,
             backend=None,
+            auth=None,
 
             **kwargs):
         """
@@ -99,6 +100,9 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             backend: A storage backend class, or an instance of a storage
                 backend class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+            auth: Authentication details details to be passed on to `requests`. This
+                can be a tuple of (<username>, <password>) or any class that `requests`
+                allows.
         """
         BaseOAuthConsumerBlueprint.__init__(
             self, name, import_name,
@@ -124,6 +128,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         self.state = state
         self.kwargs = kwargs
         self.client_secret = client_secret
+        self.auth = auth
 
         # used by view functions
         self.authorization_url = authorization_url
@@ -208,6 +213,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
                 self.token_url,
                 authorization_response=url,
                 client_secret=self.client_secret,
+                auth=self.auth,
                 **self.token_url_params
             )
         except MissingCodeError as e:

--- a/flask_dance/contrib/bitbucket.py
+++ b/flask_dance/contrib/bitbucket.py
@@ -1,0 +1,74 @@
+from __future__ import unicode_literals
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from functools import partial
+from flask.globals import LocalProxy, _lookup_app_object
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+
+
+__maintainer__ = "Christian Lerrahn <github@penpal4u.net>"
+
+
+def make_bitbucket_blueprint(
+        client_id=None, client_secret=None, scope=None, redirect_url=None,
+        redirect_to=None, login_url=None, authorized_url=None,
+        session_class=None, backend=None, auth=None):
+    """
+    Make a blueprint for authenticating with Bitbucket using OAuth 2. This requires
+    a client ID and client secret from Bitbucket. You should either pass them to
+    this constructor, or make sure that your Flask application config defines
+    them, using the variables BITBUCKET_OAUTH_CLIENT_ID and BITBUCKET_OAUTH_CLIENT_SECRET.
+
+    Args:
+        client_id (str): The client ID for your application on Bitbucket.
+        client_secret (str): The client secret for your application on Bitbucket
+        scope (str, optional): comma-separated list of scopes for the OAuth token
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/bitbucket``
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/bitbucket/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        backend: A storage backend class, or an instance of a storage
+                backend class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+        auth: Authentication credentials to be used when fetching token.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+    bitbucket_bp = OAuth2ConsumerBlueprint("bitbucket", __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url="https://bitbucket.org/",
+        authorization_url="https://bitbucket.org/site/oauth2/authorize",
+        token_url="https://bitbucket.org/site/oauth2/access_token",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        session_class=session_class,
+        backend=backend,
+        auth=(client_id, client_secret),
+    )
+    bitbucket_bp.from_config["client_id"] = "BITBUCKET_OAUTH_CLIENT_ID"
+    bitbucket_bp.from_config["client_secret"] = "BITBUCKET_OAUTH_CLIENT_SECRET"
+
+    @bitbucket_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.bitbucket_oauth = bitbucket_bp.session
+
+    return bitbucket_bp
+
+bitbucket = LocalProxy(partial(_lookup_app_object, "bitbucket_oauth"))

--- a/tests/contrib/test_bitbucket.py
+++ b/tests/contrib/test_bitbucket.py
@@ -1,0 +1,78 @@
+from __future__ import unicode_literals
+
+import pytest
+import responses
+from urlobject import URLObject
+from flask import Flask
+from flask_dance.contrib.bitbucket import make_bitbucket_blueprint, bitbucket
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.consumer.backend import MemoryBackend
+
+
+def test_blueprint_factory():
+    bitbucket_bp = make_bitbucket_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="user:email",
+        redirect_to="index",
+    )
+    assert isinstance(bitbucket_bp, OAuth2ConsumerBlueprint)
+    assert bitbucket_bp.session.scope == "user:email"
+    assert bitbucket_bp.session.base_url == "https://bitbucket.org/"
+    assert bitbucket_bp.session.client_id == "foo"
+    assert bitbucket_bp.client_secret == "bar"
+    assert bitbucket_bp.authorization_url == "https://bitbucket.org/site/oauth2/authorize"
+    assert bitbucket_bp.token_url == "https://bitbucket.org/site/oauth2/access_token"
+
+
+def test_load_from_config():
+    app = Flask(__name__)
+    app.secret_key = "anything"
+    app.config["BITBUCKET_OAUTH_CLIENT_ID"] = "foo"
+    app.config["BITBUCKET_OAUTH_CLIENT_SECRET"] = "bar"
+    bitbucket_bp = make_bitbucket_blueprint(redirect_to="index")
+    app.register_blueprint(bitbucket_bp)
+
+    resp = app.test_client().get("/bitbucket")
+    url = resp.headers["Location"]
+    client_id = URLObject(url).query.dict.get("client_id")
+    assert client_id == "foo"
+
+
+@responses.activate
+def test_context_local():
+    responses.add(responses.GET, "https://google.com")
+
+    # set up two apps with two different set of auth tokens
+    app1 = Flask(__name__)
+    ghbp1 = make_bitbucket_blueprint(
+        "foo1", "bar1", redirect_to="url1",
+        backend=MemoryBackend({"access_token": "app1"}),
+    )
+    app1.register_blueprint(ghbp1)
+
+    app2 = Flask(__name__)
+    ghbp2 = make_bitbucket_blueprint(
+        "foo2", "bar2", redirect_to="url2",
+        backend=MemoryBackend({"access_token": "app2"}),
+    )
+    app2.register_blueprint(ghbp2)
+
+    # outside of a request context, referencing functions on the `bitbucket` object
+    # will raise an exception
+    with pytest.raises(RuntimeError):
+        bitbucket.get("https://google.com")
+
+    # inside of a request context, `bitbucket` should be a proxy to the correct
+    # blueprint session
+    with app1.test_request_context("/"):
+        app1.preprocess_request()
+        bitbucket.get("https://google.com")
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer app1"
+
+    with app2.test_request_context("/"):
+        app2.preprocess_request()
+        bitbucket.get("https://google.com")
+        request = responses.calls[1].request
+        assert request.headers["Authorization"] == "Bearer app2"


### PR DESCRIPTION
Bitbucket requires HTTP Basic Authentication witch client_id and client_secret to fetch tokens. `OAuth2ConsumerBlueprint` has been adjusted to pass through authentication details (object or tuple as expected by `requests`).

A provider `Bitbucket` has been added.

Test for new provider has been added.

Documentation has been updated.