### PR TITLE
If missing "state" variable, redirect to `login` view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ unreleased
 * Removed the Dictective utility class, and replaced it with
   ``werkzeug.datastructures.CallbackDict``. It does the same thing, but
   it's better tested, and already a part of one of Flask-Dance's dependencies.
+* If the user hits the ``authorized`` view without having a "state" variable
+  set in the browser cookies, Flask-Dance will now redirect the user back
+  to the ``login`` view to start the OAuth dance all over again, rather than
+  raising a ``KeyError``.
 
 0.7.0 (2015-08-21)
 ------------------

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -192,6 +192,10 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             return redirect(next_url)
 
         state_key = "{bp.name}_oauth_state".format(bp=self)
+        if state_key not in flask.session:
+            # can't validate state, so redirect back to login view
+            return redirect(url_for(".login"))
+
         self.session._state = flask.session[state_key]
         del flask.session[state_key]
 

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -133,6 +133,21 @@ def test_authorized_url():
         )
 
 
+def test_authorized_url_no_state():
+    app, _ = make_app()
+    with app.test_client() as client:
+        # make the request, without resetting the session beforehand
+        resp = client.get(
+            "/login/test-service/authorized?code=secret-code&state=random-string",
+            base_url="https://a.b.c",
+        )
+        # check that we redirected the client back to login view
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "https://a.b.c/login/test-service"
+        # check that there's nothing in the session
+        assert "test-service_oauth_token" not in flask.session
+
+
 @responses.activate
 def test_authorized_url_behind_proxy():
     responses.add(


### PR DESCRIPTION
If the user hits the ``authorized`` view without having a "state" variable set in the browser cookies, Flask-Dance will now redirect the user back to the ``login`` view to start the OAuth dance all over again, rather than raising a ``KeyError``. Fixes #34.

@rmoorman, can you take a look at this, and test it before it gets merged?