### PR TITLE
`pkg_resources.parse_version()` instead of `distutils.StrictVersion`

### DIFF
--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function
 import six
 from lazy import lazy
 from abc import ABCMeta, abstractmethod, abstractproperty
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from werkzeug.datastructures import CallbackDict
 import flask
 from flask.signals import Namespace
@@ -34,7 +34,7 @@ class BaseOAuthConsumerBlueprint(six.with_metaclass(ABCMeta, flask.Blueprint)):
             root_path=root_path,
         )
         # `root_path` didn't exist until 1.0
-        if StrictVersion(flask.__version__) < StrictVersion('1.0'):
+        if parse_version(flask.__version__) < parse_version('1.0'):
             del bp_kwargs["root_path"]
         flask.Blueprint.__init__(self, **bp_kwargs)
 

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals, print_function
 import six
 from lazy import lazy
 from abc import ABCMeta, abstractmethod, abstractproperty
-from pkg_resources import parse_version
 from werkzeug.datastructures import CallbackDict
 import flask
 from flask.signals import Namespace
@@ -33,8 +32,9 @@ class BaseOAuthConsumerBlueprint(six.with_metaclass(ABCMeta, flask.Blueprint)):
             url_defaults=url_defaults,
             root_path=root_path,
         )
-        # `root_path` didn't exist until 1.0
-        if parse_version(flask.__version__) < parse_version('1.0'):
+        # `root_path` didn't exist in 0.10, and will cause an error if it's
+        # passed in that version. Only pass `root_path` if it's set.
+        if bp_kwargs["root_path"] is None:
             del bp_kwargs["root_path"]
         flask.Blueprint.__init__(self, **bp_kwargs)
 

--- a/tests/consumer/test_requests.py
+++ b/tests/consumer/test_requests.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 import mock
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 import requests_oauthlib
 from flask_dance.consumer.requests import OAuth1Session, OAuth2Session
 
 requires_requests_oauthlib_05 = pytest.mark.skipif(
-    StrictVersion(requests_oauthlib.__version__) < StrictVersion('0.5'),
+    parse_version(requests_oauthlib.__version__) < parse_version('0.5'),
     reason="requires requests_oauthlib at version 0.5 or higher",
 )
 


### PR DESCRIPTION
`pkg_resources.parse_version()` is more flexible. Fixes #53.

@ThiefMaster, can you try this out and let me know if it works for you?