### PR TITLE
add auto_refresh_url to oauth blueprint creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Change Log
 
 unreleased
 ----------
-nothing yet
+* Fixed ``make_google_blueprint`` to include ``auto_refresh_url`` so that
+  token renewal is automatically handled by ``requests-oauthlib``
 
 0.10.0 (2016-09-27)
 -------------------

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -66,6 +66,7 @@ def make_google_blueprint(
         base_url="https://www.googleapis.com/",
         authorization_url="https://accounts.google.com/o/oauth2/auth",
         token_url="https://accounts.google.com/o/oauth2/token",
+        auto_refresh_url="https://accounts.google.com/o/oauth2/token",
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,


### PR DESCRIPTION
The google blueprint is not setting the auto_refresh_token_url. So the token is not automatically refreshing when it has expired and a valid refresh token exists.

As per: https://github.com/requests/requests-oauthlib/blob/master/docs/oauth2_workflow.rst#third-recommended-define-automatic-token-refresh-and-update