### PR TITLE
Drop sqlalchemy_utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,9 @@ Change Log
 
 unreleased
 ----------
-nothing yet
+* Depend on SQLAlchemy 1.1 or higher, so that we can drop the dependency on
+  sqlalchemy_utils. We only needed it for the JSON type, which is now built
+  into SQLAlchemy 1.1.
 
 0.10.1 (2016-11-21)
 -------------------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,8 +9,7 @@ mock
 responses
 freezegun
 # testing sqlalchemy support
-sqlalchemy>=0.9
-sqlalchemy_utils
+sqlalchemy>=1.1
 flask-sqlalchemy
 # testing integration with other extensions
 flask-login

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -275,7 +275,6 @@ intersphinx_mapping = {
     'requests': ('http://docs.python-requests.org/en/latest/', None),
     'requests_oauthlib': ('http://requests-oauthlib.readthedocs.org/en/latest/', None),
     'sqlalchemy': ('http://docs.sqlalchemy.org/en/latest/', None),
-    'sqlalchemy_utils': ('http://sqlalchemy-utils.readthedocs.org/en/latest/', None),
 }
 
 autodoc_member_order = "bysource"

--- a/flask_dance/consumer/backend/sqla.py
+++ b/flask_dance/consumer/backend/sqla.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, JSON
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy_utils import JSONType
 from sqlalchemy.orm.exc import NoResultFound
 from flask_dance.utils import FakeCache, first, getattrd
 from flask_dance.consumer.backend import BaseBackend
@@ -27,7 +26,7 @@ class OAuthConsumerMixin(object):
         an automatically generated datetime that indicates when
         the OAuth provider issued this token
     ``token``
-        a :class:`JSON <sqlalchemy_utils.types.json.JSONType>` field to store
+        a :class:`JSON <sqlalchemy.types.JSON>` field to store
         the actual token received from the OAuth provider
     """
     @declared_attr
@@ -37,7 +36,7 @@ class OAuthConsumerMixin(object):
     id = Column(Integer, primary_key=True)
     provider = Column(String(50))
     created_at = Column(DateTime, default=datetime.utcnow)
-    token = Column(MutableDict.as_mutable(JSONType))
+    token = Column(MutableDict.as_mutable(JSON))
 
     def __repr__(self):
         parts = []

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=get_requirements("requirements.txt"),
     tests_require=get_requirements("dev-requirements.txt"),
     extras_require={
-        'sqla': ['sqlalchemy', 'sqlalchemy-utils'],
+        'sqla': ['sqlalchemy>=1.1'],
         'signals': ['blinker'],
     },
     cmdclass = {'test': PyTest},


### PR DESCRIPTION
Now that [SQLAlchemy has JSON support built-in in version 1.1 and higher](http://docs.sqlalchemy.org/en/latest/changelog/migration_11.html#json-support-added-to-core), we should depend on SQLAlchemy 1.1 and drop `sqlalchemy_utils`