### PR TITLE
timezone handling in timestamp_from_datetime

### DIFF
--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import functools
 from collections import MutableMapping
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class FakeCache(object):
@@ -50,11 +50,11 @@ def getattrd(obj, name, default=sentinel):
 
 def timestamp_from_datetime(dt):
     """
-    Given a datetime, return a float that represents the timestamp for
+    Given a datetime, in UTC, return a float that represents the timestamp for
     that datetime.
 
     http://stackoverflow.com/questions/8777753/converting-datetime-date-to-utc-timestamp-in-python#8778548
     """
     if hasattr(dt, "timestamp") and callable(dt.timestamp):
-        return dt.timestamp()
-    return (dt - datetime(1970, 1, 1)).total_seconds()
+        return dt.replace(tzinfo=timezone.utc).timestamp()
+    return (dt - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,7 +1,22 @@
 from __future__ import unicode_literals
 import functools
 from collections import MutableMapping
-from datetime import datetime, timezone
+from datetime import datetime
+
+
+try:
+    from datetime import timezone
+    utc = timezone.utc
+except ImportError:
+    from datetime import timedelta, tzinfo
+    class UTC(tzinfo):
+        def utcoffset(self, dt):
+            return timedelta(0)
+        def tzname(self, dt):
+            return "UTC"
+        def dst(self, dst):
+            return timedelta(0)
+    utc = UTC()
 
 
 class FakeCache(object):
@@ -55,6 +70,7 @@ def timestamp_from_datetime(dt):
 
     http://stackoverflow.com/questions/8777753/converting-datetime-date-to-utc-timestamp-in-python#8778548
     """
+    dt = dt.replace(tzinfo=utc)
     if hasattr(dt, "timestamp") and callable(dt.timestamp):
-        return dt.replace(tzinfo=timezone.utc).timestamp()
-    return (dt - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
+        return dt.replace(tzinfo=utc).timestamp()
+    return (dt - datetime(1970, 1, 1, tzinfo=utc)).total_seconds()


### PR DESCRIPTION
My machine was set on UTC+7.
When the **value** of `dt` in `timestamp_from_datetime(dt)` is in UTC, such as in https://github.com/singingwolfboy/flask-dance/blob/deab6261c68e7eb643b0c174a9f4f0dd873d8316/flask_dance/consumer/base.py#L113
The function will treat `dt` as it is in UTC+7.
For example, when `dt = datetime.utcnow()` and `dt` becomes "2017-01-01 00:00:00.000", `dt.timestamp()` will convert `dt` to UNIX timestamp while assuming "2017-01-01 00:00:00.000" as UTC+7