### PR TITLE
Drop dependency on sphinxcontrib-napoleon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Change Log
 
 unreleased
 ----------
-Nothing yet
+* sphinxcontrib-napoleon is no longer required to build the Flask-Dance
+  documentation.
 
 0.12.0 (2017-10-22)
 -------------------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 # documentation tools
-sphinx
-sphinxcontrib-napoleon
+sphinx>=1.3
 sphinxcontrib-seqdiag
 # testing tools
 pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'sphinxcontrib.seqdiag',
 ]
 


### PR DESCRIPTION
It was rolled into Sphinx itself as of version 1.3. Fixes #80.