### PR TITLE
Make sqla backend know when to require a user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ unreleased
   documentation.
 * Added Spotify pre-set configuration
 * Added Discord pre-set configuration
+* Added an optional ``user_required`` argument to the SQLAlchemy backend.
+  When this is enabled, trying to set an OAuth object without an associated
+  user will raise an error.
 
 0.12.0 (2017-10-22)
 -------------------

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -256,5 +256,9 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
                 set_token = False
 
         if set_token:
-            self.token = token
+            try:
+                self.token = token
+            except ValueError as error:
+                log.warning("OAuth 2 authorization error: %s", str(error))
+                oauth_error.send(self, error=error)
         return redirect(next_url)


### PR DESCRIPTION
This resolves the issue raised in #88, where Flask-Dance should have raised an exception instead of trying to create an OAuth token without an associated user. This changes the SQLAlchemy backend to take a new optional argument: `require_user`. When set to True, the backend will not allow OAuth tokens to be created without an associated user. This argument is True by default when an argument is passed for `user` or `user_id`.

@NathanWailes, can you take a look at this, and let me know if the functionality is what you had in mind?