### PR TITLE
Add Discord provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ unreleased
 * sphinxcontrib-napoleon is no longer required to build the Flask-Dance
   documentation.
 * Added Spotify pre-set configuration
+* Added Discord pre-set configuration
 
 0.12.0 (2017-10-22)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ popular websites:
 * Slack
 * Azure AD
 * Nylas
+* Spotify
+* Discord
 
 Installation
 ============

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -143,6 +143,18 @@ Spotify
     already has the Spotify authentication token loaded (assuming that the user
     has authenticated with Spotify at some point in the past).
 
+Discord
+-------
+.. module:: flask_dance.contrib.discord
+
+.. autofunction:: make_discord_blueprint
+
+.. data:: discord
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the Discord authentication token loaded (assuming that the user
+    has authenticated with Discord at some point in the past).
+
 .. _custom-provider:
 
 Custom

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from functools import partial
+from flask.globals import LocalProxy, _lookup_app_object
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+
+
+__maintainer__ = "Michael Delpech <michaeldel@protonmail.com>"
+
+
+def make_discord_blueprint(
+        client_id=None, client_secret=None, scope=None, redirect_url=None,
+        redirect_to=None, login_url=None, authorized_url=None,
+        session_class=None, backend=None):
+    """
+    Make a blueprint for authenticating with Discord using OAuth 2. This requires
+    a client ID and client secret from Discord. You should either pass them to
+    this constructor, or make sure that your Flask application config defines
+    them, using the variables DISCORD_OAUTH_CLIENT_ID and DISCORD_OAUTH_CLIENT_SECRET.
+
+    Args:
+        client_id (str): The client ID for your application on Discord.
+        client_secret (str): The client secret for your application on Discord
+        scope (str, optional): comma-separated list of scopes for the OAuth token
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/discord``
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/discord/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        backend: A storage backend class, or an instance of a storage
+                backend class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+    scope = scope or ["identify"]
+    discord_bp = OAuth2ConsumerBlueprint("discord", __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url="https://discordapp.com/",
+        token_url="https://discordapp.com/api/oauth2/token",
+        authorization_url="https://discordapp.com/api/oauth2/authorize",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        session_class=session_class,
+        backend=backend,
+    )
+    discord_bp.from_config["client_id"] = "DISCORD_OAUTH_CLIENT_ID"
+    discord_bp.from_config["client_secret"] = "DISCORD_OAUTH_CLIENT_SECRET"
+
+    @discord_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.discord_oauth = discord_bp.session
+
+    return discord_bp
+
+discord = LocalProxy(partial(_lookup_app_object, "discord_oauth"))

--- a/tests/contrib/test_discord.py
+++ b/tests/contrib/test_discord.py
@@ -1,0 +1,78 @@
+from __future__ import unicode_literals
+
+import pytest
+import responses
+from urlobject import URLObject
+from flask import Flask
+from flask_dance.contrib.discord import make_discord_blueprint, discord
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.consumer.backend import MemoryBackend
+
+
+def test_blueprint_factory():
+    discord_bp = make_discord_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope=["identify", "email"],
+        redirect_to="index",
+    )
+    assert isinstance(discord_bp, OAuth2ConsumerBlueprint)
+    assert discord_bp.session.scope == ["identify", "email"]
+    assert discord_bp.session.base_url == "https://discordapp.com/"
+    assert discord_bp.session.client_id == "foo"
+    assert discord_bp.client_secret == "bar"
+    assert discord_bp.authorization_url == "https://discordapp.com/api/oauth2/authorize"
+    assert discord_bp.token_url == "https://discordapp.com/api/oauth2/token"
+
+
+def test_load_from_config():
+    app = Flask(__name__)
+    app.secret_key = "anything"
+    app.config["DISCORD_OAUTH_CLIENT_ID"] = "foo"
+    app.config["DISCORD_OAUTH_CLIENT_SECRET"] = "bar"
+    discord_bp = make_discord_blueprint(redirect_to="index")
+    app.register_blueprint(discord_bp)
+
+    resp = app.test_client().get("/discord")
+    url = resp.headers["Location"]
+    client_id = URLObject(url).query.dict.get("client_id")
+    assert client_id == "foo"
+
+
+@responses.activate
+def test_context_local():
+    responses.add(responses.GET, "https://google.com")
+
+    # set up two apps with two different set of auth tokens
+    app1 = Flask(__name__)
+    discord_bp1 = make_discord_blueprint(
+        "foo1", "bar1", redirect_to="url1",
+        backend=MemoryBackend({"access_token": "app1"}),
+    )
+    app1.register_blueprint(discord_bp1)
+
+    app2 = Flask(__name__)
+    discord_bp2 = make_discord_blueprint(
+        "foo2", "bar2", redirect_to="url2",
+        backend=MemoryBackend({"access_token": "app2"}),
+    )
+    app2.register_blueprint(discord_bp2)
+
+    # outside of a request context, referencing functions on the `discord` object
+    # will raise an exception
+    with pytest.raises(RuntimeError):
+        discord.get("https://google.com")
+
+    # inside of a request context, `discord` should be a proxy to the correct
+    # blueprint session
+    with app1.test_request_context("/"):
+        app1.preprocess_request()
+        discord.get("https://google.com")
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer app1"
+
+    with app2.test_request_context("/"):
+        app2.preprocess_request()
+        discord.get("https://google.com")
+        request = responses.calls[1].request
+        assert request.headers["Authorization"] == "Bearer app2"


### PR DESCRIPTION
I found Flask-Dance to be the most straightforward Flask's OAuth lib so far, hence I would like to bring my contribution to it by adding the Discord provider that I use in my own projects.

Feel free to let me know if I need to edit some other things to comply with your merging requirements.