### PR TITLE
Added support for custom definition of url_for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 addons:
   postgresql: "9.4"
 env:

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -39,6 +39,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             redirect_to=None,
             session_class=None,
             backend=None,
+            _url_for=None,
 
             **kwargs):
         """
@@ -94,6 +95,8 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             backend: A storage backend class, or an instance of a storage
                 backend class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+            _url_for: A custom version of the flask ``url_for``. Defaults to
+                :func:`~flask.url_for`.
         """
         BaseOAuthConsumerBlueprint.__init__(
             self, name, import_name,
@@ -109,6 +112,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
 
         self.base_url = base_url
         self.session_class = session_class or OAuth1Session
+        self.url_for = _url_for or url_for
 
         # passed to OAuth1Session()
         self.client_key = client_key
@@ -135,7 +139,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         This is a session between the consumer (your website) and the provider
         (e.g. Twitter). It is *not* a session between a user of your website
         and your website.
-        :return: 
+        :return:
         """
         return self.session_class(
             client_key=self.client_key,
@@ -154,7 +158,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         lazy.invalidate(self, "session")
 
     def login(self):
-        callback_uri = url_for(
+        callback_uri = self.url_for(
             ".authorized", next=request.args.get('next'), _external=True,
         )
         self.session._client.client.callback_uri = to_unicode(callback_uri)
@@ -172,7 +176,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             elif self.redirect_url:
                 next_url = self.redirect_url
             elif self.redirect_to:
-                next_url = url_for(self.redirect_to)
+                next_url = self.url_for(self.redirect_to)
             else:
                 next_url = "/"
             return redirect(next_url)
@@ -191,7 +195,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         elif self.redirect_url:
             next_url = self.redirect_url
         elif self.redirect_to:
-            next_url = url_for(self.redirect_to)
+            next_url = self.url_for(self.redirect_to)
         else:
             next_url = "/"
         self.session.parse_authorization_response(request.url)

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -15,7 +15,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_github_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, **kwargs):
     """
     Make a blueprint for authenticating with GitHub using OAuth 2. This requires
     a client ID and client secret from GitHub. You should either pass them to
@@ -58,6 +58,7 @@ def make_github_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         backend=backend,
+        **kwargs
     )
     github_bp.from_config["client_id"] = "GITHUB_OAUTH_CLIENT_ID"
     github_bp.from_config["client_secret"] = "GITHUB_OAUTH_CLIENT_SECRET"


### PR DESCRIPTION
This is mostly a proposal to add a custom definition of `url_for` inside the `OAuth1ConsumerBlueprint` and `OAuth2ConsumerBlueprint`.

The reason for a custom `url_for` is that the flask `url_for` with the parameter `_external=True` does not behave well in a dockerized environment.

If this idea seems good, I am open to complete the PR and change also the other providers.