### PR TITLE
Fetch access_token from backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,9 @@ Change Log
 
 unreleased
 ----------
-Nothing yet
+* Accessing the ``access_token`` property on an instance of the
+  ``OAuth2Session`` class will now query the token backend, instead of
+  checking the client on the instance.
 
 0.13.0 (2017-11-12)
 -------------------

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -103,6 +103,10 @@ class OAuth2Session(BaseOAuth2Session):
         return False
 
     @property
+    def access_token(self):
+        return self.token and self.token.get("access_token")
+
+    @property
     def authorized(self):
         """ This is the property used when you have a statement in your code
         that reads "if <provider>.authorized:", e.g. "if twitter.authorized:".

--- a/tests/consumer/test_requests.py
+++ b/tests/consumer/test_requests.py
@@ -48,3 +48,27 @@ def test_oauth2session_not_authorized():
     bp = mock.Mock(token=None)
     sess = OAuth2Session(client_id="cid", blueprint=bp)
     assert sess.authorized == False
+
+
+def test_oauth2session_token():
+    bp = mock.Mock(token=FAKE_OAUTH2_TOKEN)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.token == FAKE_OAUTH2_TOKEN
+
+
+def test_oauth2session_unset_token():
+    bp = mock.Mock(token=None)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.token == None
+
+
+def test_oauth2session_access_token():
+    bp = mock.Mock(token=FAKE_OAUTH2_TOKEN)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.access_token == "deadbeef"
+
+
+def test_oauth2session_unset_access_token():
+    bp = mock.Mock(token=None)
+    sess = OAuth2Session(client_id="cid", blueprint=bp)
+    assert sess.access_token == None


### PR DESCRIPTION
Fixes #104. While investing that issue, I discovered that accessing the `access_token` property on an instance of the `OAuth2Session` class would only [attempt to locate an OAuth token on the client of the instance itself](https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py#L116-L118), rather than querying the token backend.

Now, the `OAuth2Session` class defines its own `access_token` property that is aware of the token backend, and will use that backend instead of the client on the instance.

@giocalitri, can you test this out and let me know if it fixes your problem?