### PR TITLE
Run travis with python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 addons:
   postgresql: "9.4"
 env:

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ),
     zip_safe=False,
 )


### PR DESCRIPTION
Everything should work out of the box, but probably it's better to run the tests with python 3.6 as well.