### PR TITLE
Don't load token prematurely for OAuth1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Change Log
 unreleased
 ----------
 * Flask-Cache is deprecated. Switch to Flask-Caching.
+* When using the OAuth 1 blueprint with the SQLAlchemy backend and the
+  ``user_required`` argument set to ``True``, the backend was trying to load
+  tokens before any were set, causing an exception in the backend.
+  Now, the backend will not attempt to load tokens until the OAuth dance
+  is complete.
 
 0.14.0 (2018-03-14)
 -------------------

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -135,7 +135,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         This is a session between the consumer (your website) and the provider
         (e.g. Twitter). It is *not* a session between a user of your website
         and your website.
-        :return: 
+        :return:
         """
         return self.session_class(
             client_key=self.client_key,
@@ -160,7 +160,10 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         self.session._client.client.callback_uri = to_unicode(callback_uri)
 
         try:
-            self.session.fetch_request_token(self.request_token_url)
+            self.session.fetch_request_token(
+                self.request_token_url,
+                should_load_token=False,
+            )
         except TokenRequestDenied as err:
             message = err.args[0]
             response = getattr(err, "response", None)
@@ -197,7 +200,10 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         self.session.parse_authorization_response(request.url)
 
         try:
-            token = self.session.fetch_access_token(self.access_token_url)
+            token = self.session.fetch_access_token(
+                self.access_token_url,
+                should_load_token=False,
+            )
         except ValueError as err:
             # can't proceed with OAuth, have to just redirect to next_url
             message = err.args[0]

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -65,8 +65,10 @@ class OAuth1Session(BaseOAuth1Session):
             request.url = self.base_url.relative(request.url)
         return super(OAuth1Session, self).prepare_request(request)
 
-    def request(self, method, url, data=None, headers=None, **kwargs):
-        self.load_token()
+    def request(self, method, url, data=None, headers=None,
+                should_load_token=True, **kwargs):
+        if should_load_token:
+            self.load_token()
         return super(OAuth1Session, self).request(
             method=method, url=url, data=data, headers=headers, **kwargs
         )


### PR DESCRIPTION
I need to think about why this change is necessary for OAuth 1, but not for OAuth 2. The protocols are different; maybe the fact that OAuth 1 needs to do a consumer-to-provider request before redirecting the user means that trying to load the token so early in the process is simply doomed to failure? Or perhaps there's a better way of solving this problem...

Related to #120.