### PR TITLE
Flask-Caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Change Log
 
 unreleased
 ----------
-Nothing yet
+* Flask-Cache is deprecated. Switch to Flask-Caching.
 
 0.14.0 (2018-03-14)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ just set it up like this:
     blueprint.backend = SQLAlchemyBackend(OAuth, db.session, user=get_current_user)
 
 The SQLAlchemy backend seamlessly integrates with `Flask-SQLAlchemy`_,
-as well as `Flask-Login`_ for user management, and `Flask-Cache`_ for caching.
+as well as `Flask-Login`_ for user management, and `Flask-Caching`_ for caching.
 
 Full Documentation
 ==================
@@ -123,7 +123,7 @@ This README provides just a taste of what Flask-Dance is capable of. To see more
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 .. _Flask-SQLAlchemy: http://pythonhosted.org/Flask-SQLAlchemy/
 .. _Flask-Login: https://flask-login.readthedocs.org/
-.. _Flask-Cache: http://pythonhosted.org/Flask-Cache/
+.. _Flask-Caching: https://flask-caching.readthedocs.io/
 
 .. |build-status| image:: https://travis-ci.org/singingwolfboy/flask-dance.svg?branch=master&style=flat
    :target: https://travis-ci.org/singingwolfboy/flask-dance

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,4 @@ sqlalchemy_utils
 flask-sqlalchemy
 # testing integration with other extensions
 flask-login
-flask-cache
+flask-caching

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -63,11 +63,11 @@ user, if you want.
 
 You also probably want to use a caching system for your database, so that it
 is more performant under heavy load. The SQLAlchemy token storage backend
-also integrates with `Flask-Cache`_ if you just pass an Flask-Cache instance
+also integrates with `Flask-Caching`_ if you just pass an Flask-Caching instance
 to the backend, like this::
 
     from flask import Flask
-    from flask_cache import Cache
+    from flask_caching import Cache
 
     app = Flask(__name__)
     cache = Cache(app)
@@ -79,7 +79,7 @@ to the backend, like this::
 
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 .. _Flask-Login: https://flask-login.readthedocs.org/
-.. _Flask-Cache: http://pythonhosted.org/Flask-Cache/
+.. _Flask-Caching: https://flask-caching.readthedocs.io/
 
 Custom
 ------

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -8,7 +8,7 @@ from lazy import lazy
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import event
 from sqlalchemy.orm.exc import NoResultFound
-from flask_cache import Cache
+from flask_caching import Cache
 from flask_login import LoginManager, UserMixin, current_user, login_user, logout_user
 from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized, oauth_error
 from flask_dance.consumer.backend.sqla import OAuthConsumerMixin, SQLAlchemyBackend


### PR DESCRIPTION
Flask-Cache is deprecated and unsupported, so we're moving to Flask-Caching instead.