### PR TITLE
Added try except to parse_authorization_response in oauth1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,7 @@ unreleased
   tokens before any were set, causing an exception in the backend.
   Now, the backend will not attempt to load tokens until the OAuth dance
   is complete.
-
-0.14.1 (2018-05-20)
--------------------
-* Fixed Oauth1 crash in ``authorized`` when Twitter provider redirects to ``/authorized`` without providing ``oauth_token``
+* Added exception handler around ``parse_authorization_response`` in Oauth1
 
 0.14.0 (2018-03-14)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ unreleased
   Now, the backend will not attempt to load tokens until the OAuth dance
   is complete.
 
+0.14.1 (2018-05-20)
+-------------------
+* Fixed Oauth1 crash in ``authorized`` when Twitter provider redirects to ``/authorized`` without providing ``oauth_token``
+
 0.14.0 (2018-03-14)
 -------------------
 * Accessing the ``access_token`` property on an instance of the

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -202,8 +202,9 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             self.session.parse_authorization_response(request.url)
         except TokenMissing as err:
             message = err.args[0]
+            response = getattr(err, "response", None)
             log.warning("OAuth 1 access token error: %s", message)
-            oauth_error.send(self, message=message)
+            oauth_error.send(self, message=message, response=response)
             return redirect(next_url)
 
         try:

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -4,7 +4,7 @@ import logging
 from lazy import lazy
 from flask import request, url_for, redirect, current_app
 from werkzeug.wrappers import Response
-from requests_oauthlib.oauth1_session import TokenRequestDenied
+from requests_oauthlib.oauth1_session import TokenRequestDenied, TokenMissing
 from oauthlib.oauth1 import SIGNATURE_HMAC, SIGNATURE_TYPE_AUTH_HEADER
 from oauthlib.common import to_unicode
 from .base import BaseOAuthConsumerBlueprint, oauth_authorized, oauth_error
@@ -200,11 +200,10 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             
         try:
             self.session.parse_authorization_response(request.url)
-        except Exception as err:
+        except TokenMissing as err:
             message = err.args[0]
-            response = getattr(err, "response", None)
             log.warning("OAuth 1 access token error: %s", message)
-            oauth_error.send(self, message=message, response=response)
+            oauth_error.send(self, message=message)
             return redirect(next_url)
 
         try:
@@ -217,7 +216,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             message = err.args[0]
             response = getattr(err, "response", None)
             log.warning("OAuth 1 access token error: %s", message)
-            oauth_error.send(self, message=message, response=response)
+            oauth_error.send(self, message=message)
             return redirect(next_url)
 
         results = oauth_authorized.send(self, token=token) or []

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -217,7 +217,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             message = err.args[0]
             response = getattr(err, "response", None)
             log.warning("OAuth 1 access token error: %s", message)
-            oauth_error.send(self, message=message)
+            oauth_error.send(self, message=message, response=response)
             return redirect(next_url)
 
         results = oauth_authorized.send(self, token=token) or []

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -441,7 +441,8 @@ def test_signal_oauth_notoken_authorized(request):
 
     assert len(calls) == 1
     assert calls[0][0] == (bp,)
-    assert calls[0][1]["message"] == "Response does not contain a token: {'denied': 'faketoken'}"
+    assert "Response does not contain a token" in calls[0][1]["message"]
+    assert calls[0][1]["response"] == {'denied':'faketoken'}
     assert resp.status_code == 302
     location = resp.headers["Location"]
     assert location == "https://a.b.c/"


### PR DESCRIPTION
When entered Twitter Oauth page and clicked"Cancel" instead of "Authorize app", Twitter propose a button to return to the original app that redirects to "/twitter/authorized?denied=xxxx".
This calls the authorized method in oauth1.py. However, the fact that the redirect url only contains a denied key and does not have an oauth_token key causes self.session.parse_authorization_response(request.url) to crash.
Adding try except around self.session.parse_authorization_response(request.url) avoids this crash.