### PR TITLE
Clarifying github example docs - http/https

### DIFF
--- a/docs/quickstarts/azure.rst
+++ b/docs/quickstarts/azure.rst
@@ -45,25 +45,28 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code, you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT`
-environment variable for it to work. For example, if you put this code in a
-file named ``azure.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+disable the HTTPS requirement imposed by ``oauthlib``, which is part of
+Flask-Dance. For example, if you put this code in a file named ``azure.py`` on
+your machine, you could run:
 
 .. code-block:: bash
 
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python azure.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------

--- a/docs/quickstarts/dropbox.rst
+++ b/docs/quickstarts/dropbox.rst
@@ -45,25 +45,28 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code locally, you must set the
-:envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable for it to work.
-For example, if you put this code in a file named ``dropbox.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
+you put this code in a file named ``dropbox.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
     $ export OAUTHLIB_RELAX_TOKEN_SCOPE=1
     $ python dropbox.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------

--- a/docs/quickstarts/github.rst
+++ b/docs/quickstarts/github.rst
@@ -42,25 +42,28 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code, you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT`
-environment variable for it to work. For example, if you put this code in a
-file named ``github.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), 
+you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable
+to disable the HTTPS requirement imposed by ``oauthlib``. For example, if
+you put this code in a file named ``github.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python github.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
-immediately.
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth
+dance immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------

--- a/docs/quickstarts/github.rst
+++ b/docs/quickstarts/github.rst
@@ -42,9 +42,9 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-If you run this code locally or without HTTPS enabled (see warning below), 
-you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable
-to disable the HTTPS requirement imposed by ``oauthlib``. For example, if
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
 you put this code in a file named ``github.py`` on your machine, you could
 run:
 
@@ -53,8 +53,8 @@ run:
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python github.py
 
-Visit `http://localhost:5000`_ in your browser, and you should start the OAuth
-dance immediately.
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
+immediately.
 
 .. _localhost:5000: http://localhost:5000/
 

--- a/docs/quickstarts/google.rst
+++ b/docs/quickstarts/google.rst
@@ -48,11 +48,11 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code locally, you must set the
-:envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable for it to work.
-You also must set the :envvar:`OAUTHLIB_RELAX_TOKEN_SCOPE` environment variable
-to account for Google changing the requested OAuth scopes on you.
-For example, if you put this code in a file named ``google.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
+you put this code in a file named ``google.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
@@ -60,16 +60,17 @@ For example, if you put this code in a file named ``google.py``, you could run:
     $ export OAUTHLIB_RELAX_TOKEN_SCOPE=1
     $ python google.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
     However, you can (and probably should) set
     :envvar:`OAUTHLIB_RELAX_TOKEN_SCOPE` when running in production.

--- a/docs/quickstarts/meetup.rst
+++ b/docs/quickstarts/meetup.rst
@@ -44,25 +44,28 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code locally, you must set the
-:envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable for it to work.
-For example, if you put this code in a file named ``meetup.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
+you put this code in a file named ``meetup.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
     $ export OAUTHLIB_RELAX_TOKEN_SCOPE=1
     $ python meetup.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------

--- a/docs/quickstarts/nylas.rst
+++ b/docs/quickstarts/nylas.rst
@@ -44,25 +44,28 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code, you must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT`
-environment variable for it to work. For example, if you put this code in a
-file named ``nylas.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
+you put this code in a file named ``nylas.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python nylas.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------

--- a/docs/quickstarts/slack.rst
+++ b/docs/quickstarts/slack.rst
@@ -59,16 +59,17 @@ For example, if you put this code in a file named ``slack.py``, you could run:
     $ export OAUTHLIB_RELAX_TOKEN_SCOPE=1
     $ python slack.py
 
-Visit `localhost:5000`_ in your browser, and you should start the OAuth dance
+Visit `http://localhost:5000`_ in your browser, and you should start the OAuth dance
 immediately.
 
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
     However, you can (and probably should) set
     :envvar:`OAUTHLIB_RELAX_TOKEN_SCOPE` when running in production.

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -43,9 +43,11 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
-When you run this code locally, you must set the
-:envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable for it to work.
-For example, if you put this code in a file named ``twitter.py``, you could run:
+If you run this code locally or without HTTPS enabled (see warning below), you
+must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
+to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if
+you put this code in a file named ``twitter.py`` on your machine, you could
+run:
 
 .. code-block:: bash
 
@@ -58,10 +60,11 @@ immediately.
 .. _localhost:5000: http://localhost:5000/
 
 .. warning::
-    Do *NOT* set :envvar:`OAUTHLIB_INSECURE_TRANSPORT` in production. Setting
-    this variable allows you to use insecure ``http`` for OAuth communication.
-    However, for security, all OAuth interactions must occur over secure
-    ``https`` when running in production.
+    :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
+    or over trusted connections. By default, all OAuth interactions must occur
+    over secure ``https`` connections (this is enfored by ``oauthlib``). However,
+    setting :envvar:`OAUTHLIB_INSECURE_TRANSPORT` disables this enforcement and
+    allows OAuth to occur over insecure ``http`` connections.
 
 Explanation
 -----------


### PR DESCRIPTION
- clarifying the purpose of OAUTHLIB_INSECURE_TRANSPORT
- "production" is less clear, use "local" or "trusted connection"
- add a few additional hints to the user about what's going on