### PR TITLE
Improve build mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/_build
 build
 venv/
 MANIFEST
+.tox
+.pytest_cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
     path = docs/_themes
-    url = git://github.com/Turbo87/flask-sphinx-themes.git
+    url = https://github.com/Turbo87/flask-sphinx-themes.git

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,3 +15,18 @@ To also use the :ref:`SQLAlchemy backend <sqlalchemy-backend>`, specify the
     $ pip install Flask-Dance[sqla]
 
 .. _pip: https://pip.pypa.io
+
+Library development
+============
+
+Use `tox`_ to execute unit tests on multiple python versions.
+To build the documentation, it requires the `flask-dance` theme (using git `submodule`).
+
+
+.. code-block:: bash
+
+   $ git submodule update
+   $ tox
+
+
+.. _tox: https://tox.readthedocs.io/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27-sqlite{,-blinker},py34-sqlite{,-blinker},py35-sqlite{,-blinker},py36-sqlite{,-blinker}
+
+[testenv]
+deps=
+    -rdev-requirements.txt
+    -rrequirements.txt
+    blinker: blinker
+    codecov
+setenv=DATABASE_URI=sqlite://
+commands=py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-sqlite{,-blinker},py34-sqlite{,-blinker},py35-sqlite{,-blinker},py36-sqlite{,-blinker}
+envlist = py27-sqlite{,-blinker},py34-sqlite{,-blinker},py35-sqlite{,-blinker},py36-sqlite{,-blinker},docs
 
 [testenv]
 deps=
@@ -9,3 +9,11 @@ deps=
     codecov
 setenv=DATABASE_URI=sqlite://
 commands=py.test
+
+[testenv:docs]
+basepython=python2.7
+skipsdist=True
+deps=-rdev-requirements.txt
+changedir=docs
+whitelist_externals=make
+commands=make clean html

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv=DATABASE_URI=sqlite://
 commands=py.test
 
 [testenv:docs]
-basepython=python2.7
+basepython=python3.5
 skipsdist=True
 deps=-rdev-requirements.txt
 changedir=docs


### PR DESCRIPTION
I've added tox file to reproduce the TravisCI build and ReadTheDocs build, **before** pushing changes to GitHub.
At the moment, it does not support the `postgresql` build variant, because it implies to have a postgresql installed on the developer machine. However, we can consider adding it.
Also, the `tox -e docs` is reproducing the exact steps of readthedocs website, i.e. python2.7, and should help when proposing documentation changes in PR.

Why I have added this ? It allows upstream libraries e.g. `oauthlib` to run the `flask-dance` unit tests before releasing new `oauthlib` versions.