### PR TITLE
google: Update default scope

### DIFF
--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -27,7 +27,7 @@ def make_google_blueprint(
         client_id (str): The client ID for your application on Google
         client_secret (str): The client secret for your application on Google
         scope (str, optional): comma-separated list of scopes for the OAuth token.
-            Defaults to the "profile" scope.
+            Defaults to the "https://www.googleapis.com/auth/userinfo.profile" scope.
         offline (bool): Whether to request `offline access
             <https://developers.google.com/accounts/docs/OAuth2WebServer#offline>`_
             for the OAuth token. Defaults to False
@@ -53,7 +53,7 @@ def make_google_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    scope = scope or ["profile"]
+    scope = scope or ["https://www.googleapis.com/auth/userinfo.profile"]
     authorization_url_params = {}
     if offline:
         authorization_url_params["access_type"] = "offline"

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -16,7 +16,7 @@ def test_blueprint_factory():
         redirect_to="index",
     )
     assert isinstance(google_bp, OAuth2ConsumerBlueprint)
-    assert google_bp.session.scope == ["profile"]
+    assert google_bp.session.scope == ["https://www.googleapis.com/auth/userinfo.profile"]
     assert google_bp.session.base_url == "https://www.googleapis.com/"
     assert google_bp.session.client_id == "foo"
     assert google_bp.client_secret == "bar"


### PR DESCRIPTION
Use the full scope. Something's changed on Google's side that now really requires the `OAUTHLIB_RELAX_TOKEN_SCOPE` to be set when using "short" scopes, for some reason that worked before without it. Since this is not extensively documented and the default now causes things to break, update the default to something that works without additional configuration/caveats.

Fixes #148