### PR TITLE
Updated default scopes according to recent moves from Azure.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Change Log
 unreleased
 ----------
 * Added ``tenant`` argument to ``make_azure_blueprint``
+* Updated Azure AD default scopes. See `issue 149`_.
 
 1.0.0 (2018-06-04)
 ------------------
@@ -229,3 +230,4 @@ unreleased
 * Initial release
 
 .. _issue 53: https://github.com/singingwolfboy/flask-dance/issues/53
+.. _issue 149: https://github.com/singingwolfboy/flask-dance/issues/149

--- a/docs/quickstarts/azure.rst
+++ b/docs/quickstarts/azure.rst
@@ -32,7 +32,7 @@ Code
             return redirect(url_for("azure.login"))
         resp = azure.get("/v1.0/me")
         assert resp.ok
-        return "You are {mail} on Azure AD".format(mail=resp.json()["mail"])
+        return "You are {mail} on Azure AD".format(mail=resp.json()["userPrincipalName"])
 
     if __name__ == "__main__":
         app.run()

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -50,7 +50,7 @@ def make_azure_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    scope = scope or ["user.read"]
+    scope = scope or ["openid", "email", "profile", "User.Read"]
     azure_bp = OAuth2ConsumerBlueprint("azure", __name__,
         client_id=client_id,
         client_secret=client_secret,


### PR DESCRIPTION
Microsoft updated their api to be more "openid" compliant.  ( [v1-v2-comparison](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-compare) )

The graph scope "user.read" has been replaced by "User.Read" or "https://graph.microsoft.com/user.read". 
It is seems enough for personal accounts (like outlook.com), but openid scopes are needed for entreprise accounts ("openid", "profile", "email").
"User.Read" scope is still needed in order to get an access_token.

It is related to singingwolfboy/flask-dance#149 issue.

And I also updated the example in order to display the email in both cases (personal or enterprise account)