### PR TITLE
google: Set auto_refresh_url only for offline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ unreleased
 ----------
 * Added ``tenant`` argument to ``make_azure_blueprint``
 * Updated Azure AD default scopes. See `issue 149`_.
+* Only set ``auto_refresh_url`` in ``make_google_blueprint`` if a token of
+  type ``offline`` is requested. See issues `#143`_, `#144`_ and `#161`_ for
+  background.
 
 1.0.0 (2018-06-04)
 ------------------
@@ -231,3 +234,6 @@ unreleased
 
 .. _issue 53: https://github.com/singingwolfboy/flask-dance/issues/53
 .. _issue 149: https://github.com/singingwolfboy/flask-dance/issues/149
+.. _#143: https://github.com/singingwolfboy/flask-dance/issues/143
+.. _#144: https://github.com/singingwolfboy/flask-dance/issues/144
+.. _#161: https://github.com/singingwolfboy/flask-dance/issues/161

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -55,8 +55,10 @@ def make_google_blueprint(
     """
     scope = scope or ["https://www.googleapis.com/auth/userinfo.profile"]
     authorization_url_params = {}
+    auto_refresh_url = None
     if offline:
         authorization_url_params["access_type"] = "offline"
+        auto_refresh_url = "https://accounts.google.com/o/oauth2/token"
     if reprompt_consent:
         authorization_url_params["approval_prompt"] = "force"
     google_bp = OAuth2ConsumerBlueprint("google", __name__,
@@ -66,7 +68,7 @@ def make_google_blueprint(
         base_url="https://www.googleapis.com/",
         authorization_url="https://accounts.google.com/o/oauth2/auth",
         token_url="https://accounts.google.com/o/oauth2/token",
-        auto_refresh_url="https://accounts.google.com/o/oauth2/token",
+        auto_refresh_url=auto_refresh_url,
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -22,6 +22,7 @@ def test_blueprint_factory():
     assert google_bp.client_secret == "bar"
     assert google_bp.authorization_url == "https://accounts.google.com/o/oauth2/auth"
     assert google_bp.token_url == "https://accounts.google.com/o/oauth2/token"
+    assert google_bp.auto_refresh_url is None
 
 
 def test_load_from_config():
@@ -46,6 +47,16 @@ def test_blueprint_factory_scope():
         redirect_to="index",
     )
     assert google_bp.session.scope == "customscope"
+
+
+def test_blueprint_factory_offline():
+    google_bp = make_google_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        redirect_to="index",
+        offline=True,
+    )
+    assert google_bp.auto_refresh_url == "https://accounts.google.com/o/oauth2/token"
 
 
 @responses.activate


### PR DESCRIPTION
Only when we request an offline token do we actually get a refresh token that can be used with the `auto_refresh_url` endpoint to refresh the token. As such, when we get an online token instead (the default) we shouldn't set `auto_refresh_url`.

This is the first part of the changes discussed in #143, #144 and just ensures that requests-oauthlib no longer tries to refresh an online token but immediately raises a `TokenExpiredError`. This does not constitute an API change since the resulting error is the same, but would at least result in a more clear traceback.