### PR TITLE
Add Google hosted domain (hd) url parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Added
 ~~~~~
 * Added ``tenant`` argument to ``make_azure_blueprint``
+* Added ``hd`` argument to ``make_google_blueprint``
 
 Fixed
 ~~~~~
@@ -14,7 +15,6 @@ Fixed
 * Only set ``auto_refresh_url`` in ``make_google_blueprint`` if a token of
   type ``offline`` is requested. See issues `#143`_, `#144`_ and `#161`_ for
   background.
-* Added ``hd`` argument to ``make_google_blueprint``
 
 `1.0.0`_ (2018-06-04)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Added
 ~~~~~
 * Added ``tenant`` argument to ``make_azure_blueprint``
-* Added ``hd`` argument to ``make_google_blueprint``
+* Added ``hosted_domain`` argument to ``make_google_blueprint``
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 * Only set ``auto_refresh_url`` in ``make_google_blueprint`` if a token of
   type ``offline`` is requested. See issues `#143`_, `#144`_ and `#161`_ for
   background.
+* Added ``hd`` argument to ``make_google_blueprint``
 
 `1.0.0`_ (2018-06-04)
 ------------------

--- a/docs/quickstarts/google.rst
+++ b/docs/quickstarts/google.rst
@@ -51,6 +51,11 @@ Code
     If you are running this code on Heroku, you'll need to use the
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
+.. note::
+    If you are using the ``hosted_domain`` argument, be aware that this only provides UI optimization
+    and is not a way of restricting access to users of a single domain. See the ``make_google_blueprint``
+    :ref:`documentation warning <google_hosted_domain_warning>`.
+
 If you run this code locally or without HTTPS enabled (see warning below), you
 must set the :envvar:`OAUTHLIB_INSECURE_TRANSPORT` environment variable to
 to disable the HTTPS requirement imposed by ``oauthlib``, which is part of Flask-Dance. For example, if

--- a/docs/quickstarts/google.rst
+++ b/docs/quickstarts/google.rst
@@ -52,7 +52,7 @@ Code
     :class:`werkzeug.contrib.fixers.ProxyFix` middleware. See :doc:`../proxies`.
 
 .. note::
-    If you are using the ``hosted_domain`` argument, be aware that this only provides UI optimization
+    If you set the ``hosted_domain`` argument of ``make_google_blueprint``, be aware that this only provides UI optimization
     and is not a way of restricting access to users of a single domain. See the ``make_google_blueprint``
     :ref:`documentation warning <google_hosted_domain_warning>`.
 

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -56,8 +56,8 @@ def make_google_blueprint(
     .. _google_hosted_domain_warning:
     .. warning::
        The ``hosted_domain`` argument **only provides UI optimization**. Don't rely on this argument to control
-       who can access your application. You must verify that the ``hd`` parameter of the response matches the
-       ``hosted_domain`` argument of ``make_google_blueprint``. For example:
+       who can access your application. You must verify that the ``hd`` claim of the response ID token matches the
+       ``hosted_domain`` argument passed to ``make_google_blueprint``. For example:
 
        .. code-block:: python
 
@@ -78,9 +78,9 @@ def make_google_blueprint(
                 resp_json = google.get("/oauth2/v2/userinfo").json()
                 if resp_json["hd"] != blueprint.authorization_url_params["hd"]:
                     google.authenticated = False
-                    requests.post('https://accounts.google.com/o/oauth2/revoke',
-                                  params={'token': token['access_token']},
-                                  headers={'content-type': 'application/x-www-form-urlencoded'})
+                    requests.post("https://accounts.google.com/o/oauth2/revoke",
+                                  params={"token": token["access_token"]},
+                                  headers={"content-type": "application/x-www-form-urlencoded"})
                     session.clear()
                     abort(403)
 

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -77,10 +77,10 @@ def make_google_blueprint(
             def logged_in(blueprint, token):
                 resp_json = google.get("/oauth2/v2/userinfo").json()
                 if resp_json["hd"] != blueprint.authorization_url_params["hd"]:
-                    google.authenticated = False
-                    requests.post("https://accounts.google.com/o/oauth2/revoke",
-                                  params={"token": token["access_token"]},
-                                  headers={"content-type": "application/x-www-form-urlencoded"})
+                    requests.post(
+                        "https://accounts.google.com/o/oauth2/revoke",
+                        params={"token": token["access_token"]}
+                    )
                     session.clear()
                     abort(403)
 

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -16,7 +16,7 @@ def make_google_blueprint(
         client_id=None, client_secret=None, scope=None,
         offline=False, reprompt_consent=False,
         redirect_url=None, redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None, hd=None):
+        session_class=None, backend=None, hosted_domain=None):
     """
     Make a blueprint for authenticating with Google using OAuth 2. This requires
     a client ID and client secret from Google. You should either pass them to
@@ -49,8 +49,40 @@ def make_google_blueprint(
         backend: A storage backend class, or an instance of a storage
                 backend class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.backend.session.SessionBackend`.
-        hd (str, optional): The domain of the G Suite user. Used to indicate that the account selection UI should be
-            optimized for accounts at this domain.
+        hosted_domain (str, optional): The domain of the G Suite user. Used to indicate that the account selection UI
+            should be optimized for accounts at this domain. Note that this only provides UI optimization, and requires
+            response validation (see warning).
+
+    .. _google_hosted_domain_warning:
+    .. warning::
+       The ``hosted_domain`` argument **only provides UI optimization**. Don't rely on this argument to control
+       who can access your application. You must verify that the ``hd`` parameter of the response matches the
+       ``hosted_domain`` argument of ``make_google_blueprint``. For example:
+
+       .. code-block:: python
+
+            from flask_dance.consumer import oauth_authorized
+            from flask_dance.contrib.google import make_google_blueprint, google
+            import requests
+
+            google_bp = make_google_blueprint(
+                client_id="foo",
+                client_secret="bar",
+                scope=["profile", "email"],
+                hosted_domain="example.com"
+            )
+
+            @oauth_authorized.connect_via(google_bp)
+            def logged_in(blueprint, token):
+                resp_json = google.get("/oauth2/v2/userinfo").json()
+                if resp_json["hd"] != blueprint.authorization_url_params["hd"]:
+                    google.authenticated = False
+                    requests.post('https://accounts.google.com/o/oauth2/revoke',
+                                  params={'token': token['access_token']},
+                                  headers={'content-type': 'application/x-www-form-urlencoded'})
+                    session.clear()
+                    abort(403)
+
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -63,8 +95,8 @@ def make_google_blueprint(
         auto_refresh_url = "https://accounts.google.com/o/oauth2/token"
     if reprompt_consent:
         authorization_url_params["approval_prompt"] = "force"
-    if hd:
-        authorization_url_params["hd"] = hd
+    if hosted_domain:
+        authorization_url_params["hd"] = hosted_domain
     google_bp = OAuth2ConsumerBlueprint("google", __name__,
         client_id=client_id,
         client_secret=client_secret,

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -16,7 +16,7 @@ def make_google_blueprint(
         client_id=None, client_secret=None, scope=None,
         offline=False, reprompt_consent=False,
         redirect_url=None, redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, hd=None):
     """
     Make a blueprint for authenticating with Google using OAuth 2. This requires
     a client ID and client secret from Google. You should either pass them to
@@ -49,6 +49,8 @@ def make_google_blueprint(
         backend: A storage backend class, or an instance of a storage
                 backend class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+        hd (str, optional): The domain of the G Suite user. Used to indicate that the account selection UI should be
+            optimized for accounts at this domain.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -61,6 +63,8 @@ def make_google_blueprint(
         auto_refresh_url = "https://accounts.google.com/o/oauth2/token"
     if reprompt_consent:
         authorization_url_params["approval_prompt"] = "force"
+    if hd:
+        authorization_url_params["hd"] = hd
     google_bp = OAuth2ConsumerBlueprint("google", __name__,
         client_id=client_id,
         client_secret=client_secret,

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -61,6 +61,7 @@ def make_google_blueprint(
 
        .. code-block:: python
 
+            from flask import session, abort
             from flask_dance.consumer import oauth_authorized
             from flask_dance.contrib.google import make_google_blueprint, google
             import requests

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -59,12 +59,12 @@ def test_blueprint_factory_offline():
     assert google_bp.auto_refresh_url == "https://accounts.google.com/o/oauth2/token"
 
 
-def test_blueprint_factory_hd():
+def test_blueprint_factory_hosted_domain():
     google_bp = make_google_blueprint(
         client_id="foo",
         client_secret="bar",
         redirect_to="index",
-        hd="example.com",
+        hosted_domain="example.com",
     )
 
     assert google_bp.authorization_url_params["hd"] == "example.com"
@@ -130,7 +130,7 @@ def test_offline():
 def test_hd():
     app = Flask(__name__)
     app.secret_key = "backups"
-    goog_bp = make_google_blueprint("foo", "bar", hd="example.com")
+    goog_bp = make_google_blueprint("foo", "bar", hosted_domain="example.com")
     app.register_blueprint(goog_bp)
 
     with app.test_client() as client:


### PR DESCRIPTION
Adds a `hosted_domain` argument to `make_google_blueprint`. 


From Google OpenID Connect [docs](https://developers.google.com/identity/protocols/OpenIDConnect#hd-param):
>The hd (hosted domain) parameter streamlines the login process for G Suite hosted accounts. By including the domain of the G Suite user (for example, mycollege.edu), you can indicate that the account selection UI should be optimized for accounts at that domain.

Related to #165.

**Example:**

```python
blueprint = make_google_blueprint(
    client_id="my-key-here",
    client_secret="my-secret-here",
    scope=["profile", "email"],
    hosted_domain="example.com"
)
```

![image](https://user-images.githubusercontent.com/1350214/44535596-5d130e00-a6c8-11e8-8acf-8ac648a898fc.png)
