### PR TITLE
Update Google quickstart docs

### DIFF
--- a/docs/quickstarts/google.rst
+++ b/docs/quickstarts/google.rst
@@ -25,7 +25,10 @@ Code
     blueprint = make_google_blueprint(
         client_id="my-key-here",
         client_secret="my-secret-here",
-        scope=["profile", "email"]
+        scope=[
+            "https://www.googleapis.com/auth/plus.me",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ]
     )
     app.register_blueprint(blueprint, url_prefix="/login")
 


### PR DESCRIPTION
The scopes provided were a bit misleading compared to what actually is
needed to get up and running.