### PR TITLE
travis: Only build pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
   - BLINKER=1 DATABASE_URI=postgresql://localhost/travis_ci_test
   - BLINKER=1 DATABASE_URI=sqlite://
   - BLINKER=0 DATABASE_URI=sqlite://
+
+branches:
+  only:
+  - master
+
 before_script:
   - if [[ $DATABASE_URI == postgresql* ]]; then psql -c 'create database travis_ci_test;' -U postgres; fi
 install:


### PR DESCRIPTION
With the current configuration, any push to any branch will trigger a build. Usually that's unnecesary, as Travis always (separately) also builds the PR.

This changes the configuration such that
* We don't build any branch that gets pushed to except for master
* Any branch for which a PR is opened will automatically be built
* Any branch for which a PR is open that gets new commits pushed to will be built