### PR TITLE
docs:sqla: Allow functionality out-of-the-box

### DIFF
--- a/docs/quickstarts/sqla-multiuser.rst
+++ b/docs/quickstarts/sqla-multiuser.rst
@@ -42,9 +42,13 @@ Create a file called ``multi.py`` with the following contents:
 
     class User(db.Model, UserMixin):
         id = db.Column(db.Integer, primary_key=True)
+        # Your User model can include whatever columns you want: Flask-Dance doesn't care.
+        # Here are a few columns you might find useful, but feel free to modify them
+        # as your application needs!
         username = db.Column(db.String(256), unique=True)
-        # ... other columns as needed
-
+        email = db.Column(db.String(256), unique=True)
+        name = db.Column(db.String(256))
+  
     class OAuth(OAuthConsumerMixin, db.Model):
         provider_user_id = db.Column(db.String(256), unique=True)
         user_id = db.Column(db.Integer, db.ForeignKey(User.id))


### PR DESCRIPTION
Allow the sqlalchemy example to run out-of-the-box without modifications but clarify that model attributes are entirely up to the end-user and not Flask-Dance specific.