### PR TITLE
Add option for facebook blueprint to rerequest authorization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* Added ``rerequest_declined_permissions`` argument to facebook blueprint
 
 `1.1.0`_ (2018-09-12)
 ---------------------

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -14,7 +14,7 @@ __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
 
 def make_facebook_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
-        redirect_to=None, login_url=None, authorized_url=None,rerequest_auth=False,
+        redirect_to=None, login_url=None, authorized_url=None, rerequest_declined_permissions=False,
         session_class=None, backend=None):
     """
     Make a blueprint for authenticating with Facebook using OAuth 2. This requires
@@ -35,7 +35,8 @@ def make_facebook_blueprint(
             Defaults to ``/facebook``
         authorized_url (str, optional): the URL path for the ``authorized`` view.
             Defaults to ``/facebook/authorized``.
-        rerequest_auth (bool, optional): should the blueprint ask again for declined premissions
+        rerequest_declined_permissions (bool, optional): should the blueprint ask again for declined permissions.
+            Defaults to ``False``
         session_class (class, optional): The class to use for creating a
             Requests session. Defaults to
             :class:`~flask_dance.consumer.requests.OAuth2Session`.
@@ -46,21 +47,24 @@ def make_facebook_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
+    authorization_url_params = {}
+    if rerequest_declined_permissions:
+        authorization_url_params['auth_type'] = 'rerequest'
     facebook_bp = OAuth2ConsumerBlueprint("facebook", __name__,
-        client_id=client_id,
-        client_secret=client_secret,
-        scope=scope,
-        base_url="https://graph.facebook.com/",
-        authorization_url="https://www.facebook.com/dialog/oauth",
-        authorization_url_params={'auth_type':'rerequest'},
-        token_url="https://graph.facebook.com/oauth/access_token",
-        redirect_url=redirect_url,
-        redirect_to=redirect_to,
-        login_url=login_url,
-        authorized_url=authorized_url,
-        session_class=session_class,
-        backend=backend,
-    )
+                                          client_id=client_id,
+                                          client_secret=client_secret,
+                                          scope=scope,
+                                          base_url="https://graph.facebook.com/",
+                                          authorization_url="https://www.facebook.com/dialog/oauth",
+                                          authorization_url_params=authorization_url_params,
+                                          token_url="https://graph.facebook.com/oauth/access_token",
+                                          redirect_url=redirect_url,
+                                          redirect_to=redirect_to,
+                                          login_url=login_url,
+                                          authorized_url=authorized_url,
+                                          session_class=session_class,
+                                          backend=backend,
+                                          )
     facebook_bp.from_config["client_id"] = "FACEBOOK_OAUTH_CLIENT_ID"
     facebook_bp.from_config["client_secret"] = "FACEBOOK_OAUTH_CLIENT_SECRET"
 
@@ -70,5 +74,6 @@ def make_facebook_blueprint(
         ctx.facebook_oauth = facebook_bp.session
 
     return facebook_bp
+
 
 facebook = LocalProxy(partial(_lookup_app_object, "facebook_oauth"))

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -14,7 +14,7 @@ __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
 
 def make_facebook_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
-        redirect_to=None, login_url=None, authorized_url=None,
+        redirect_to=None, login_url=None, authorized_url=None,rerequest_auth=False,
         session_class=None, backend=None):
     """
     Make a blueprint for authenticating with Facebook using OAuth 2. This requires
@@ -35,6 +35,7 @@ def make_facebook_blueprint(
             Defaults to ``/facebook``
         authorized_url (str, optional): the URL path for the ``authorized`` view.
             Defaults to ``/facebook/authorized``.
+        rerequest_auth (bool, optional): should the blueprint ask again for declined premissions
         session_class (class, optional): The class to use for creating a
             Requests session. Defaults to
             :class:`~flask_dance.consumer.requests.OAuth2Session`.
@@ -51,6 +52,7 @@ def make_facebook_blueprint(
         scope=scope,
         base_url="https://graph.facebook.com/",
         authorization_url="https://www.facebook.com/dialog/oauth",
+        authorization_url_params={'auth_type':'rerequest'},
         token_url="https://graph.facebook.com/oauth/access_token",
         redirect_url=redirect_url,
         redirect_to=redirect_to,

--- a/tests/contrib/test_facebook.py
+++ b/tests/contrib/test_facebook.py
@@ -99,5 +99,7 @@ def test_rerequest_declined_scopes(rerequest):
         )
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
-    # Using dict.get because the "auth_type" header might not be set - this is valid behaviour
-    assert (location.query_dict.get("auth_type") == "rerequest") == rerequest
+    if rerequest:
+        assert location.query_dict["auth_type"] == "rerequest"
+    else:
+        assert "auth_type" not in location.query_dict

--- a/tests/contrib/test_facebook.py
+++ b/tests/contrib/test_facebook.py
@@ -80,6 +80,12 @@ def test_context_local():
 
 @pytest.mark.parametrize("rerequest", (True, False))
 def test_rerequest_declined_scopes(rerequest):
+    """
+    Tests that the rerequest_declined_permissions flag in the facebook blueprint sends
+    toggles the header reasking oauth permissions as detailed in the facebook docs https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#reaskperms
+
+    Tests both that the header is set with the flag (rerequest=True) and that it is missing without the flag (rerequest=False)
+    """
     app = Flask(__name__)
     app.secret_key = "backups"
     bp = make_facebook_blueprint(
@@ -93,4 +99,5 @@ def test_rerequest_declined_scopes(rerequest):
         )
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
+    # Using dict.get because the "auth_type" header might not be set - this is valid behaviour
     assert (location.query_dict.get("auth_type") == "rerequest") == rerequest

--- a/tests/contrib/test_facebook.py
+++ b/tests/contrib/test_facebook.py
@@ -76,3 +76,37 @@ def test_context_local():
         facebook.get("https://google.com")
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "Bearer app2"
+
+def test_rerequest_declined_scopes():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    bp = make_facebook_blueprint(
+        scope='user_posts', rerequest_declined_permissions=True)
+    app.register_blueprint(bp)
+    with app.test_client() as client:
+        resp = client.get(
+            "/facebook",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    location = URLObject(resp.headers["Location"])
+    assert location.query_dict.get("auth_type") == "rerequest"
+
+
+def test_dont_rerequest_declined_scopes():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    bp = make_facebook_blueprint(
+        scope='user_posts', rerequest_declined_permissions=False)
+    app.register_blueprint(bp)
+    with app.test_client() as client:
+        resp = client.get(
+            "/facebook",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    location = URLObject(resp.headers["Location"])
+    # Using dict.get because the header might not be set, it will still result in valid behaviour
+    assert location.query_dict.get("auth_type") != "rerequest"


### PR DESCRIPTION
Prior to this change, if an existing user tried to login after refusing
an authorization scope, the dialog would just redirect him to sucess
without asking again for the missing scopes.

Sarting from this commit, using a flag and as documented
[here](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#reaskperms) a blueprint can be set to re-request the declined scopes