### PR TITLE
added blueprint_name default parameter

### DIFF
--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -15,7 +15,7 @@ __maintainer__ = "Steven MARTINS <steven.martins.fr@gmail.com>"
 def make_azure_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None, tenant="common"):
+        session_class=None, backend=None, tenant="common", blueprint_name="azure"):
     """
     Make a blueprint for authenticating with Azure AD using OAuth 2. This requires
     a client ID and client secret from Azure AD. You should either pass them to
@@ -51,7 +51,7 @@ def make_azure_blueprint(
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
     scope = scope or ["openid", "email", "profile", "User.Read"]
-    azure_bp = OAuth2ConsumerBlueprint("azure", __name__,
+    azure_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -15,7 +15,7 @@ __maintainer__ = "Michael Delpech <michaeldel@protonmail.com>"
 def make_discord_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name="discord"):
     """
     Make a blueprint for authenticating with Discord using OAuth 2. This requires
     a client ID and client secret from Discord. You should either pass them to
@@ -46,7 +46,7 @@ def make_discord_blueprint(
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
     scope = scope or ["identify"]
-    discord_bp = OAuth2ConsumerBlueprint("discord", __name__,
+    discord_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -17,7 +17,7 @@ def make_dropbox_blueprint(
         force_reapprove=False, disable_signup=False, require_role=None,
         redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None,blueprint_name="dropbox"):
     """
     Make a blueprint for authenticating with Dropbox using OAuth 2. This requires
     a client ID and client secret from Dropbox. You should either pass them to
@@ -66,7 +66,7 @@ def make_dropbox_blueprint(
     if require_role:
         authorization_url_params["require_role"] = require_role
 
-    dropbox_bp = OAuth2ConsumerBlueprint("dropbox", __name__,
+    dropbox_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=app_key,
         client_secret=app_secret,
         scope=scope,

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -15,7 +15,7 @@ __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
 def make_facebook_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name="facebook"):
     """
     Make a blueprint for authenticating with Facebook using OAuth 2. This requires
     a client ID and client secret from Facebook. You should either pass them to
@@ -45,7 +45,7 @@ def make_facebook_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    facebook_bp = OAuth2ConsumerBlueprint("facebook", __name__,
+    facebook_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -15,7 +15,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_github_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name="github"):
     """
     Make a blueprint for authenticating with GitHub using OAuth 2. This requires
     a client ID and client secret from GitHub. You should either pass them to
@@ -45,7 +45,7 @@ def make_github_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    github_bp = OAuth2ConsumerBlueprint("github", __name__,
+    github_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -15,7 +15,7 @@ __maintainer__ = "Justin Georgeson <jgeorgeson@lopht.net>"
 def make_gitlab_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None, hostname="gitlab.com"):
+        session_class=None, backend=None, hostname="gitlab.com", blueprint_name="gitlab"):
     """
     Make a blueprint for authenticating with GitLab using OAuth 2. This requires
     a client ID and client secret from GitLab. You should either pass them to
@@ -47,7 +47,7 @@ def make_gitlab_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    gitlab_bp = OAuth2ConsumerBlueprint("gitlab", __name__,
+    gitlab_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -16,7 +16,7 @@ def make_google_blueprint(
         client_id=None, client_secret=None, scope=None,
         offline=False, reprompt_consent=False,
         redirect_url=None, redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None, hosted_domain=None):
+        session_class=None, backend=None, hosted_domain=None,blueprint_name='google'):
     """
     Make a blueprint for authenticating with Google using OAuth 2. This requires
     a client ID and client secret from Google. You should either pass them to
@@ -52,6 +52,7 @@ def make_google_blueprint(
         hosted_domain (str, optional): The domain of the G Suite user. Used to indicate that the account selection UI
             should be optimized for accounts at this domain. Note that this only provides UI optimization, and requires
             response validation (see warning).
+        blueprint_name (str, optional): The name of the blueprint, this allows use google login in another blueprint
 
     .. _google_hosted_domain_warning:
     .. warning::
@@ -98,7 +99,7 @@ def make_google_blueprint(
         authorization_url_params["approval_prompt"] = "force"
     if hosted_domain:
         authorization_url_params["hd"] = hosted_domain
-    google_bp = OAuth2ConsumerBlueprint("google", __name__,
+    google_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -25,7 +25,7 @@ class JsonOAuth1Session(OAuth1Session):
 def make_jira_blueprint(
         base_url, consumer_key=None, rsa_key=None,
         redirect_url=None, redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name='jira'):
     """
     Make a blueprint for authenticating with JIRA using OAuth 1. This requires
     a consumer key and RSA key for the JIRA appication link. You should either
@@ -65,7 +65,7 @@ def make_jira_blueprint(
             rsa_key = f.read()
     base_url = URLObject(base_url)
 
-    jira_bp = OAuth1ConsumerBlueprint("jira", __name__,
+    jira_bp = OAuth1ConsumerBlueprint(blueprint_name, __name__,
         client_key=consumer_key,
         rsa_key=rsa_key,
         signature_method=SIGNATURE_RSA,

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -16,7 +16,7 @@ def make_meetup_blueprint(
         key=None, secret=None, scope=None,
         redirect_url=None, redirect_to=None,
         login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name='meetup'):
     """
     Make a blueprint for authenticating with Meetup using OAuth 2. This requires
     an OAuth consumer from Meetup. You should either pass the key and secret to
@@ -47,7 +47,7 @@ def make_meetup_blueprint(
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
     scope = scope or ["basic"]
-    meetup_bp = OAuth2ConsumerBlueprint("meetup", __name__,
+    meetup_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=key,
         client_secret=secret,
         scope=scope,

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -16,7 +16,7 @@ def make_nylas_blueprint(
         client_id=None, client_secret=None, scope="email",
         redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name='nylas'):
     """
     Make a blueprint for authenticating with Nylas using OAuth 2. This requires
     an API ID and API secret from Nylas. You should either pass them to
@@ -48,7 +48,7 @@ def make_nylas_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
-    nylas_bp = OAuth2ConsumerBlueprint("nylas", __name__,
+    nylas_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,

--- a/flask_dance/contrib/okta.py
+++ b/flask_dance/contrib/okta.py
@@ -15,7 +15,7 @@ __maintainer__ = "Tom Nolan <tomnolan95@gmail.com>"
 def make_okta_blueprint(
         client_id=None, client_secret=None, base_url=None, scope=None, redirect_url=None,
         token_url=None, redirect_to=None, login_url=None, authorization_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, blueprint_name='okta'):
     """
     Make a blueprint for authenticating with Okta using OAuth 2. This requires
     a client ID and client secret from OKta. You should either pass them to
@@ -46,7 +46,7 @@ def make_okta_blueprint(
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
     scope = scope or ["openid", "email", "profile"]
-    okta_bp = OAuth2ConsumerBlueprint("okta", __name__,
+    okta_bp = OAuth2ConsumerBlueprint(blueprint_name, __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,


### PR DESCRIPTION
I have used flask_dance for a project and noticed that we cannot use "make_google_blueprint" function in more than one file, as the name of the blueprint is default to "google" in google.py file ( there cannot be same files with the same blueprint name ), I have added a Keyword argument in the "make_google_blueprint" function as blueprint_name=" google". So while creating a google_blueprint, in more than one file, the blueprint_name can be set accordingly, to avoid same blueprint name error