### PR TITLE
Pin oauthlib to avoid breakage with 3.0.0 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.0
-oauthlib
+oauthlib>=2.1.0,<3.0.0
 requests-oauthlib>=1.0.0
 Flask>=0.7
 urlobject


### PR DESCRIPTION
We're going to release OAuthLib 3.0.0 soon, which contains some breaking changes.

This PR is to avoid problems before we are able to address the compatibility.