### PR TITLE
Add option to allow CSRF attacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* Added option to allow CSRF attacks, needed for Slack apps.
+  See `#191`_.
 
 `1.2.0`_ (2018-12-05)
 ---------------------
@@ -259,6 +260,7 @@ Fixed
 .. _#143: https://github.com/singingwolfboy/flask-dance/issues/143
 .. _#144: https://github.com/singingwolfboy/flask-dance/issues/144
 .. _#161: https://github.com/singingwolfboy/flask-dance/issues/161
+.. _#191: https://github.com/singingwolfboy/flask-dance/issues/191
 
 
 .. _unreleased: https://github.com/singingwolfboy/flask-dance/compare/v1.2.0...HEAD

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -21,7 +21,7 @@ class SlackBlueprint(OAuth2ConsumerBlueprint):
 def make_slack_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None):
+        session_class=None, backend=None, allow_csrf=False):
     """
     Make a blueprint for authenticating with Slack using OAuth 2. This requires
     a client ID and client secret from Slack. You should either pass them to
@@ -45,8 +45,14 @@ def make_slack_blueprint(
             Requests session. Defaults to
             :class:`~flask_dance.consumer.requests.OAuth2Session`.
         backend: A storage backend class, or an instance of a storage
-                backend class, to use for this blueprint. Defaults to
-                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+            backend class, to use for this blueprint. Defaults to
+            :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+        allow_csrf (bool): Allow `CSRF attacks
+            <https://en.wikipedia.org/wiki/Cross-site_request_forgery>`_.
+            If you want to allow users to install your Slack app directly
+            from the `Slack app directory <https://slack.com/apps>`_,
+            you will need to set this option to ``True``, since doing this
+            is indistinguishable from a CSRF attack.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -65,6 +71,7 @@ def make_slack_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         backend=backend,
+        allow_csrf=allow_csrf,
     )
     slack_bp.from_config["client_id"] = "SLACK_OAUTH_CLIENT_ID"
     slack_bp.from_config["client_secret"] = "SLACK_OAUTH_CLIENT_SECRET"


### PR DESCRIPTION
Fixes #191. Slack apps can be installed from the [Slack app directory](https://slack.com/apps), which involves doing the OAuth dance starting from slack.com instead of from the Flask app. This is the same as a [cross-site request forgery attack](https://en.wikipedia.org/wiki/Cross-site_request_forgery), but it is the expected behavior.

Is there some way that we can narrow the scope of this vulnerability? Is there a reliable way to _only_ bypass the `state` check for requests that were initiated by a subdomain of `slack.com`, for example? I don't know if `Referer` headers are reliable or not...