### PR TITLE
Allow weak route with no CSRF protection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 `unreleased`_
 -------------
 
-* Added option to allow CSRF attacks, needed for Slack apps.
+* Added option to disable CSRF protection, needed for Slack app installation from app directory.
   See `#191`_.
 
 `1.2.0`_ (2018-12-05)

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -14,6 +14,81 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 
 
 class SlackBlueprint(OAuth2ConsumerBlueprint):
+    def __init__(self, name, import_name,
+            client_id=None,
+            client_secret=None,
+            client=None,
+            auto_refresh_url=None,
+            auto_refresh_kwargs=None,
+            scope=None,
+            state=None,
+
+            static_folder=None, static_url_path=None, template_folder=None,
+            url_prefix=None, subdomain=None, url_defaults=None, root_path=None,
+
+            login_url=None,
+            authorized_url=None,
+            base_url=None,
+            authorization_url=None,
+            authorization_url_params=None,
+            token_url=None,
+            token_url_params=None,
+            redirect_url=None,
+            redirect_to=None,
+            session_class=None,
+            backend=None,
+            enable_slack_app_directory=False,
+            **kwargs):
+        """
+        Most of the constructor arguments are forwarded either to the
+        :class:`flask.Blueprint` constructor or the
+        :class:`requests_oauthlib.OAuth2Session` constructor, including
+        ``**kwargs`` (which is forwarded to
+        :class:`~requests_oauthlib.OAuth2Session`).
+        :param: enable_slack_app_directory
+        Defaults to False. If set to True, modifies ``authorized_url``
+        to ``{authorized_url}/strong`` and the original ``authorized_url``
+        view does not check OAuth ``state``.
+        """
+        if enable_slack_app_directory:
+            weak_authorized_url = authorized_url or "/{bp.name}/authorized"
+            authorized_url = weak_authorized_url.rstrip("/") + "/strong"
+
+        OAuth2ConsumerBlueprint.__init__(
+            self, name, import_name,
+            client_id=client_id,
+            client_secret=client_secret,
+            client=client,
+            auto_refresh_url=auto_refresh_url,
+            auto_refresh_kwargs=auto_refresh_kwargs,
+            scope=scope,
+            state=state,
+
+            static_folder=static_folder, static_url_path=static_url_path, template_folder=template_folder,
+            url_prefix=url_prefix, subdomain=subdomain, url_defaults=url_defaults, root_path=root_path,
+
+            login_url=login_url,
+            authorized_url=authorized_url,
+            base_url=base_url,
+            authorization_url=authorization_url,
+            authorization_url_params=authorization_url_params,
+            token_url=token_url,
+            token_url_params=token_url_params,
+            redirect_url=redirect_url,
+            redirect_to=redirect_to,
+            session_class=session_class,
+            backend=backend,
+
+            **kwargs
+        )
+
+        if enable_slack_app_directory:
+            self.add_url_rule(
+                rule=weak_authorized_url.format(bp=self),
+                endpoint="weak_authorized",
+                view_func=partial(self.authorized, check_state=False),
+            )
+
     def session_created(self, session):
         return slack_compliance_fix(session)
 
@@ -21,7 +96,7 @@ class SlackBlueprint(OAuth2ConsumerBlueprint):
 def make_slack_blueprint(
         client_id=None, client_secret=None, scope=None, redirect_url=None,
         redirect_to=None, login_url=None, authorized_url=None,
-        session_class=None, backend=None, allow_csrf=False):
+        session_class=None, backend=None, enable_slack_app_directory=False):
     """
     Make a blueprint for authenticating with Slack using OAuth 2. This requires
     a client ID and client secret from Slack. You should either pass them to
@@ -40,19 +115,22 @@ def make_slack_blueprint(
         login_url (str, optional): the URL path for the ``login`` view.
             Defaults to ``/slack``
         authorized_url (str, optional): the URL path for the ``authorized`` view.
-            Defaults to ``/slack/authorized``.
+            Defaults to ``/slack/authorized``. If ``enable_slack_app_directory``
+            is set to `True`, defaults to ``/slack/authorized/strong``
         session_class (class, optional): The class to use for creating a
             Requests session. Defaults to
             :class:`~flask_dance.consumer.requests.OAuth2Session`.
         backend: A storage backend class, or an instance of a storage
-            backend class, to use for this blueprint. Defaults to
-            :class:`~flask_dance.consumer.backend.session.SessionBackend`.
-        allow_csrf (bool): Allow `CSRF attacks
-            <https://en.wikipedia.org/wiki/Cross-site_request_forgery>`_.
-            If you want to allow users to install your Slack app directly
-            from the `Slack app directory <https://slack.com/apps>`_,
-            you will need to set this option to ``True``, since doing this
-            is indistinguishable from a CSRF attack.
+                backend class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.backend.session.SessionBackend`.
+        enable_slack_app_directory: Defaults to False.
+            If set to `True`, appends `/strong` to ``authorized_url`` and
+            passes this URL as redirect_uri to the provider. `/strong`
+            will require presence (and matching) of `state` value from
+            the provider, and the original ``authorized_url`` will not require it.
+            This is needed to avoid double authorization when installing
+            Slack app from Slack directory, but weakens security by not
+            implementing CSRF protection on the original ``authorized_url`` path.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -71,7 +149,7 @@ def make_slack_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         backend=backend,
-        allow_csrf=allow_csrf,
+        enable_slack_app_directory=enable_slack_app_directory
     )
     slack_bp.from_config["client_id"] = "SLACK_OAUTH_CLIENT_ID"
     slack_bp.from_config["client_secret"] = "SLACK_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -17,22 +17,9 @@ class SlackBlueprint(OAuth2ConsumerBlueprint):
     def __init__(self, name, import_name,
             client_id=None,
             client_secret=None,
-            client=None,
-            auto_refresh_url=None,
-            auto_refresh_kwargs=None,
             scope=None,
-            state=None,
-
-            static_folder=None, static_url_path=None, template_folder=None,
-            url_prefix=None, subdomain=None, url_defaults=None, root_path=None,
-
             login_url=None,
             authorized_url=None,
-            base_url=None,
-            authorization_url=None,
-            authorization_url_params=None,
-            token_url=None,
-            token_url_params=None,
             redirect_url=None,
             redirect_to=None,
             session_class=None,
@@ -58,27 +45,13 @@ class SlackBlueprint(OAuth2ConsumerBlueprint):
             self, name, import_name,
             client_id=client_id,
             client_secret=client_secret,
-            client=client,
-            auto_refresh_url=auto_refresh_url,
-            auto_refresh_kwargs=auto_refresh_kwargs,
             scope=scope,
-            state=state,
-
-            static_folder=static_folder, static_url_path=static_url_path, template_folder=template_folder,
-            url_prefix=url_prefix, subdomain=subdomain, url_defaults=url_defaults, root_path=root_path,
-
             login_url=login_url,
             authorized_url=authorized_url,
-            base_url=base_url,
-            authorization_url=authorization_url,
-            authorization_url_params=authorization_url_params,
-            token_url=token_url,
-            token_url_params=token_url_params,
             redirect_url=redirect_url,
             redirect_to=redirect_to,
             session_class=session_class,
             backend=backend,
-
             **kwargs
         )
 
@@ -115,8 +88,8 @@ def make_slack_blueprint(
         login_url (str, optional): the URL path for the ``login`` view.
             Defaults to ``/slack``
         authorized_url (str, optional): the URL path for the ``authorized`` view.
-            Defaults to ``/slack/authorized``. If ``enable_slack_app_directory``
-            is set to `True`, defaults to ``/slack/authorized/strong``
+            Defaults to ``/slack/authorized``. Can be implicitly modified
+            if ``enable_slack_app_directory`` parameter is set to True.
         session_class (class, optional): The class to use for creating a
             Requests session. Defaults to
             :class:`~flask_dance.consumer.requests.OAuth2Session`.

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 import re
 from oauthlib.oauth2 import MissingCodeError
+from functools import partial
 
 try:
     from urllib.parse import quote_plus, parse_qsl
@@ -155,7 +156,8 @@ def test_authorized_url_csrf():
         "https://example.com/oauth/access_token",
         body='{"access_token":"foobar","token_type":"bearer","scope":"admin"}',
     )
-    app, _ = make_app(allow_csrf=True)
+    app, bp = make_app()
+    bp.authorized = partial(bp.authorized, check_state=False)
     with app.test_client() as client:
         # make the request, without resetting the session beforehand
         resp = client.get(


### PR DESCRIPTION
Hi, @daenney and @singingwolfboy,

Kindly review the proposed changes.

I have reworked your branch and instead of globally weakening security for Slack, I added an `enable_slack_app_directory` option to `make_slack_blueprint` function and `SlackBlueprint` blueprint. If this parameter is set to True, `SlackBlueprint` creates both weak and strong OAuth routes - `/login/slack/authorized` and `/login/slack/authorized/strong`.

I wanted to make `/login/slack/weak_authorized`, but [Slack docs](https://api.slack.com/docs/oauth#redirect_urls) say that 
```
The redirect URL's path must reference a subdirectory of the callback URL
```
So I had to do it this way.

If `enable_slack_app_directory` is omitted or set to False, the blueprint functions the same way as before.