### PR TITLE
Update to the twitter quickstart about the domain requirement and when to use hyperlink vs an http lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 .cache
 .idea/
+.vscode/
 htmlcov
 dist
 docs/_build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": "${workspaceFolder}/docs"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
-}

--- a/docs/quickstarts/twitter-frontend.rst
+++ b/docs/quickstarts/twitter-frontend.rst
@@ -1,0 +1,70 @@
+Twitter Frontend Quickstart
+===========================
+
+Prerequisite
+------------
+Please see the `twitter <twitter.rst>`_ document before
+reading this implementation. You are familiar with
+frontend libraries like React, Angular, or VueJS and have worked
+with components, webpack, and other JS libaries like axios.
+
+Set up the application
+----------------------
+In this demo, I have used 127.0.0.1 instead of localhost after
+I experienced the issue in this `tech note <https://twittercommunity.com/t/why-cant-i-use-localhost-as-my-oauth-callback/708>`_.
+
+Github Demo
+-----------
+You can find the complete source for this demo in this `flask-dance-twitter-frontend <https://github.com/headwinds/flask-dance-twitter-frontend>`_ github.
+Please note that this demo does not yet include the
+`sql backend <slqa-multiuser.rst>`_ that hangs onto the token
+after the flask session has expired.
+
+Code
+----
+Once your project has compiled, please view visit ``http://127.0.0.1:5000`` in your browser.
+Then, you can click on the Signin with Twitter hyperlink.
+
+In your signin view, make sure you use a hyperlink or button that
+will redirect the user to a confirmation webpage that Twitter provides.
+
+.. code-block:: HTML
+
+    <a href="/api/twitter/aut">Sign in with Twitter</a>
+
+You can only use RESTFUL libraries like axios to get the
+authentication status.
+
+For instance, when the component mounts, you could call a function to check
+the authentication status against Twitter's API.
+
+If the authentication fails, then you can display a hyperlink for
+the user to begin the dance, or if it succeeds, then simply
+display the authenticated username.
+
+The following example uses axios and vuejs but this could be ported to
+react, angular, or vanila javascript. You could create 3 state variables:
+welcome (String ""), authenticated (Boolean false),
+authenticateCheckComplete (Boolean false), and then use these to
+either show the hyperlink or the authenticated username.
+
+.. code-block:: javascript
+
+    function checkAuthentication(){
+        const self = this;
+
+        const url = (document.domain === "127.0.0.1")
+            ? 'http://127.0.0.1:5000/twitter/auth' : 'https://your-production-domain/twitter/auth'
+
+        axios.get(url).then(
+            response => {
+                if (response.data.screen_name) {
+                    self.welcome = "welcome " + response.data.screen_name;
+                    self.authenticated = true;
+                }
+            }
+        ).catch(error => {
+            this.errored = error
+        }).finally(() => self.authenticateCheckComplete = true);
+
+    }

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -60,7 +60,7 @@ immediately.
 In your view, make sure you use a plain hyperlink to begin the dance so that redirect loads Twitter's page in the browser. 
 
 ```
-<a href="http://127.0.0.1:5000/twitter/login">Sign in with Twitter</a>
+<a href="/twitter/login">Sign in with Twitter</a>
 ```
 
 You can only use http libraries like axios to check the authentication status. For instance, when the component mounts, you can call a function to check 

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -5,7 +5,7 @@ Set up the application
 ----------------------
 Go to Twitter Application Manager at https://apps.twitter.com and create a
 new app. The application's "Callback URL" must be
-``http://127.0.0.1:5000/login/twitter/authorized``. `localhost:5000` will not work!
+``http://127.0.0.1:5000/login/twitter/authorized``. The domain ``localhost`` will not work with Twitter!
 Take note of the "API Key" and "API Secret" for the application.
 
 
@@ -54,48 +54,51 @@ run:
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python twitter.py
 
-Visit http://127.0.0.1:5000 in your browser, and you should start the OAuth dance
-immediately.
+Visit ``http://127.0.0.1:5000`` in your browser, and you should start the OAuth dance
+immediately after you click on the Signin with Twitter hyperlink.
 
-In your view, make sure you use a plain hyperlink to begin the dance so that the redirect loads Twitter's confirmation page in the browser. 
+In your view, make sure you use a plain hyperlink to begin the dance
+so that the redirect loads Twitter's confirmation page in the browser.
 
-```
-<a href="/twitter/login">Sign in with Twitter</a>
-```
+.. code-block:: HTML
 
-You can only use http libraries like axios to check the authentication status. 
+    <a href="/twitter/login">Sign in with Twitter</a>
 
-For instance, when the component mounts, you can call a function to check the authentication status. 
+You can only use http libraries like axios to check the
+authentication status.
 
-If the authentication fails, then you can display a hyperlink for the user to begin the dance. 
+For instance, when the component mounts, you can call a function to check
+the authentication status. If the authentication fails, then
+you can display a hyperlink for the user to begin the dance, or
+if it succeeds, then simply display the authenticated username.
 
-If it succeeds, then simply display the authenticated username. 
+The following example uses axios and vuejs but this could be ported to
+react, angular, or vanila javascript. You could create 3 state variables:
+welcome (String ""), authenticated (Boolean false),
+authenticateCheckComplete (Boolean false), and then use these to
+either show the hyperlink or the authenticated username.
 
-```
-// an example using axios and vuejs but this could be ported to react, angular, or vanilajs
-// create 3 state variables: welcome (String ""), authenticated (Boolean false), authenticateCheckComplete (Boolean false)
-// if (!authenticated && authenticateCheckComplete) show the hyperlink 
-// if (authenticated && authenticateCheckComplete) show the username 
+.. code-block:: javascript
 
-const url = (document.domain === "127.0.0.1") ? 'http://127.0.0.1:5000/twitter/auth' : 'https://your-production-domain/twitter/auth'
+    function checkAuthentication(){
+        const self = this;
 
-function checkAuthentication(){
-    const self = this;
+        const url = (document.domain === "127.0.0.1")
+            ? 'http://127.0.0.1:5000/twitter/auth' : 'https://your-production-domain/twitter/auth'
 
-    axios.get(url).then( 
-        response => {
-            if (response.data.screen_name) {
-                self.welcome = "welcome " + response.data.screen_name;
-                self.authenticated = true;
+        axios.get(url).then(
+            response => {
+                if (response.data.screen_name) {
+                    self.welcome = "welcome " + response.data.screen_name;
+                    self.authenticated = true;
+                }
             }
-        }
-    ).catch(error => {
-        this.errored = error
-    }).finally(() => self.authenticateCheckComplete = true);
+        ).catch(error => {
+            this.errored = error
+        }).finally(() => self.authenticateCheckComplete = true);
 
-}
+    }
 
-```
 
 .. warning::
     :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -57,25 +57,27 @@ run:
 Visit http://127.0.0.1:5000 in your browser, and you should start the OAuth dance
 immediately.
 
-In your view, make sure you use a plain hyperlink to begin the dance so that redirect loads Twitter's page in the browser. 
+In your view, make sure you use a plain hyperlink to begin the dance so that the redirect loads Twitter's confirmation page in the browser. 
 
 ```
 <a href="/twitter/login">Sign in with Twitter</a>
 ```
 
-You can only use http libraries like axios to check the authentication status. For instance, when the component mounts, you can call a function to check 
-the authentication status. 
+You can only use http libraries like axios to check the authentication status. 
+
+For instance, when the component mounts, you can call a function to check the authentication status. 
 
 If the authentication fails, then you can display a hyperlink for the user to begin the dance. 
 
 If it succeeds, then simply display the authenticated username. 
 
 ```
+// an example using axios and vuejs but this could be ported to react, angular, or vanilajs
 // create 3 state variables: welcome (String ""), authenticated (Boolean false), authenticateCheckComplete (Boolean false)
-// !authenticated && authenticateCheckComplete show the hyperlink 
-// authenticated && authenticateCheckComplete show the username 
+// if (!authenticated && authenticateCheckComplete) show the hyperlink 
+// if (authenticated && authenticateCheckComplete) show the username 
 
-const url = (document.domain === "127.0.0.1") ? 'http://127.0.0.1:5000/twitter/auth' : 'https://production-domain/twitter/auth'
+const url = (document.domain === "127.0.0.1") ? 'http://127.0.0.1:5000/twitter/auth' : 'https://your-production-domain/twitter/auth'
 
 function checkAuthentication(){
     const self = this;
@@ -94,8 +96,6 @@ function checkAuthentication(){
 }
 
 ```
-
-
 
 .. warning::
     :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -5,7 +5,7 @@ Set up the application
 ----------------------
 Go to Twitter Application Manager at https://apps.twitter.com and create a
 new app. The application's "Callback URL" must be
-``http://127.0.0.1:5000/login/twitter/authorized``. The domain ``localhost`` will not work with Twitter!
+``http://localhost:5000/login/twitter/authorized``.
 Take note of the "API Key" and "API Secret" for the application.
 
 
@@ -24,7 +24,7 @@ Code
     )
     app.register_blueprint(blueprint, url_prefix="/login")
 
-    @app.route("/twitter/login")
+    @app.route("/")
     def index():
         if not twitter.authorized:
             return redirect(url_for("twitter.login"))
@@ -54,51 +54,8 @@ run:
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python twitter.py
 
-Visit ``http://127.0.0.1:5000`` in your browser, and you should start the OAuth dance
-immediately after you click on the Signin with Twitter hyperlink.
-
-In your view, make sure you use a plain hyperlink to begin the dance
-so that the redirect loads Twitter's confirmation page in the browser.
-
-.. code-block:: HTML
-
-    <a href="/twitter/login">Sign in with Twitter</a>
-
-You can only use http libraries like axios to check the
-authentication status.
-
-For instance, when the component mounts, you can call a function to check
-the authentication status. If the authentication fails, then
-you can display a hyperlink for the user to begin the dance, or
-if it succeeds, then simply display the authenticated username.
-
-The following example uses axios and vuejs but this could be ported to
-react, angular, or vanila javascript. You could create 3 state variables:
-welcome (String ""), authenticated (Boolean false),
-authenticateCheckComplete (Boolean false), and then use these to
-either show the hyperlink or the authenticated username.
-
-.. code-block:: javascript
-
-    function checkAuthentication(){
-        const self = this;
-
-        const url = (document.domain === "127.0.0.1")
-            ? 'http://127.0.0.1:5000/twitter/auth' : 'https://your-production-domain/twitter/auth'
-
-        axios.get(url).then(
-            response => {
-                if (response.data.screen_name) {
-                    self.welcome = "welcome " + response.data.screen_name;
-                    self.authenticated = true;
-                }
-            }
-        ).catch(error => {
-            this.errored = error
-        }).finally(() => self.authenticateCheckComplete = true);
-
-    }
-
+Visit http://localhost:5000 in your browser, and you should start the OAuth dance
+immediately.
 
 .. warning::
     :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing
@@ -127,3 +84,8 @@ you can use all the normal ``requests`` methods, like
 :meth:`~requests.Session.get` and :meth:`~requests.Session.post`,
 to make HTTP requests. If you only specify the path component of the URL,
 the domain will default to ``https://www.googleapis.com``.
+
+Frontend Demo
+-------------
+Please see the `twitter-frontend <twitter-frontend.rst>`_ doc as one
+of many possible approaches to implementing flask-dance.

--- a/docs/quickstarts/twitter.rst
+++ b/docs/quickstarts/twitter.rst
@@ -5,7 +5,7 @@ Set up the application
 ----------------------
 Go to Twitter Application Manager at https://apps.twitter.com and create a
 new app. The application's "Callback URL" must be
-``http://localhost:5000/login/twitter/authorized``.
+``http://127.0.0.1:5000/login/twitter/authorized``. `localhost:5000` will not work!
 Take note of the "API Key" and "API Secret" for the application.
 
 
@@ -24,7 +24,7 @@ Code
     )
     app.register_blueprint(blueprint, url_prefix="/login")
 
-    @app.route("/")
+    @app.route("/twitter/login")
     def index():
         if not twitter.authorized:
             return redirect(url_for("twitter.login"))
@@ -54,8 +54,48 @@ run:
     $ export OAUTHLIB_INSECURE_TRANSPORT=1
     $ python twitter.py
 
-Visit http://localhost:5000 in your browser, and you should start the OAuth dance
+Visit http://127.0.0.1:5000 in your browser, and you should start the OAuth dance
 immediately.
+
+In your view, make sure you use a plain hyperlink to begin the dance so that redirect loads Twitter's page in the browser. 
+
+```
+<a href="http://127.0.0.1:5000/twitter/login">Sign in with Twitter</a>
+```
+
+You can only use http libraries like axios to check the authentication status. For instance, when the component mounts, you can call a function to check 
+the authentication status. 
+
+If the authentication fails, then you can display a hyperlink for the user to begin the dance. 
+
+If it succeeds, then simply display the authenticated username. 
+
+```
+// create 3 state variables: welcome (String ""), authenticated (Boolean false), authenticateCheckComplete (Boolean false)
+// !authenticated && authenticateCheckComplete show the hyperlink 
+// authenticated && authenticateCheckComplete show the username 
+
+const url = (document.domain === "127.0.0.1") ? 'http://127.0.0.1:5000/twitter/auth' : 'https://production-domain/twitter/auth'
+
+function checkAuthentication(){
+    const self = this;
+
+    axios.get(url).then( 
+        response => {
+            if (response.data.screen_name) {
+                self.welcome = "welcome " + response.data.screen_name;
+                self.authenticated = true;
+            }
+        }
+    ).catch(error => {
+        this.errored = error
+    }).finally(() => self.authenticateCheckComplete = true);
+
+}
+
+```
+
+
 
 .. warning::
     :envvar:`OAUTHLIB_INSECURE_TRANSPORT` should only be used for local testing


### PR DESCRIPTION
First off - your library is fantastic - thank you for creating it!!!

I went through the Twitter auth today and had a couple hiccups:

1. Twitter requires http://127.0.0.1:5000 not http://localhost:5000 in the callback
2. I was attempting to use axios from the frontend instead of a simple hyperlink. I wanted to point this out in the quick start because I bet a lot of modern devs will probably try to use a library instead of a hyperlink if they haven't done the oath dance before. 

[demo](https://probe.now.sh/)