### PR TITLE
Add `authorization_required` decorator on session

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 `unreleased`_
 -------------
 
+* Add ``authorization_required`` decorator
 * Added Authentiq pre-set configuration
 
 `1.2.0`_ (2018-12-05)

--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,8 @@ If you want your users to be able to log in to your app from any of the
     app.register_blueprint(blueprint, url_prefix="/login")
 
     @app.route("/")
+    @github.authorization_required
     def index():
-        if not github.authorized:
-            return redirect(url_for("github.login"))
         resp = github.get("/user")
         assert resp.ok
         return "You are @{login} on GitHub".format(login=resp.json()["login"])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -117,3 +117,11 @@ Backends
    :members:
    :special-members:
 
+Sessions
+--------
+
+.. autoclass:: flask_dance.consumer.requests.OAuth1Session
+   :members: token, authorized, authorization_required
+
+.. autoclass:: flask_dance.consumer.requests.OAuth2Session
+   :members: token, access_token, authorized, authorization_required

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -29,6 +29,9 @@ class OAuth1Session(BaseOAuth1Session):
 
     @lazy
     def token(self):
+        """
+        Get and set the values in the OAuth token, structured as a dictionary.
+        """
         return self.blueprint.token
 
     def load_token(self):
@@ -56,8 +59,6 @@ class OAuth1Session(BaseOAuth1Session):
         (see base.py), which calls 'backend.get()' to actually try to load
         the token from the cache/db (see the 'get()' function in
         backend/sqla.py).
-
-        :return:
         """
         self.load_token()
         return super(OAuth1Session, self).authorized
@@ -117,6 +118,9 @@ class OAuth2Session(BaseOAuth2Session):
 
     @lazy
     def token(self):
+        """
+        Get and set the values in the OAuth token, structured as a dictionary.
+        """
         return self.blueprint.token
 
     def load_token(self):
@@ -128,6 +132,9 @@ class OAuth2Session(BaseOAuth2Session):
 
     @property
     def access_token(self):
+        """
+        Returns the ``access_token`` from the OAuth token.
+        """
         return self.token and self.token.get("access_token")
 
     @property
@@ -145,8 +152,6 @@ class OAuth2Session(BaseOAuth2Session):
         (see base.py), which calls 'backend.get()' to actually try to load
         the token from the cache/db (see the 'get()' function in
         backend/sqla.py).
-
-        :return:
         """
         self.load_token()
         return super(OAuth2Session, self).authorized

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -66,6 +66,8 @@ class OAuth1Session(BaseOAuth1Session):
     @property
     def authorization_required(self):
         """
+        .. versionadded:: 1.3.0
+
         This is a decorator for a view function. If the current user does not
         have an OAuth token, then they will be redirected to the
         :meth:`~flask_dance.consumer.oauth1.OAuth1ConsumerBlueprint.login`
@@ -160,6 +162,8 @@ class OAuth2Session(BaseOAuth2Session):
     @property
     def authorization_required(self):
         """
+        .. versionadded:: 1.3.0
+
         This is a decorator for a view function. If the current user does not
         have an OAuth token, then they will be redirected to the
         :meth:`~flask_dance.consumer.oauth2.OAuth2ConsumerBlueprint.login`

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals, print_function
 
+from functools import wraps
+from flask import redirect, url_for
 from lazy import lazy
 from urlobject import URLObject
 from requests_oauthlib import OAuth1Session as BaseOAuth1Session
@@ -59,6 +61,26 @@ class OAuth1Session(BaseOAuth1Session):
         """
         self.load_token()
         return super(OAuth1Session, self).authorized
+
+    @property
+    def authorization_required(self):
+        """
+        This is a decorator for a view function. If the current user does not
+        have an OAuth token, then they will be redirected to the ``login``
+        view to obtain one.
+        """
+        def wrapper(func):
+
+            @wraps(func)
+            def check_authorization(*args, **kwargs):
+                if not self.authorized:
+                    endpoint = "{name}.login".format(name=self.blueprint.name)
+                    return redirect(url_for(endpoint))
+                return func(*args, **kwargs)
+
+            return check_authorization
+
+        return wrapper
 
     def prepare_request(self, request):
         if self.base_url:
@@ -128,6 +150,26 @@ class OAuth2Session(BaseOAuth2Session):
         """
         self.load_token()
         return super(OAuth2Session, self).authorized
+
+    @property
+    def authorization_required(self):
+        """
+        This is a decorator for a view function. If the current user does not
+        have an OAuth token, then they will be redirected to the ``login``
+        view to obtain one.
+        """
+        def wrapper(func):
+
+            @wraps(func)
+            def check_authorization(*args, **kwargs):
+                if not self.authorized:
+                    endpoint = "{name}.login".format(name=self.blueprint.name)
+                    return redirect(url_for(endpoint))
+                return func(*args, **kwargs)
+
+            return check_authorization
+
+        return wrapper
 
     def request(self, method, url, data=None, headers=None, **kwargs):
         if self.base_url:

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -67,7 +67,8 @@ class OAuth1Session(BaseOAuth1Session):
     def authorization_required(self):
         """
         This is a decorator for a view function. If the current user does not
-        have an OAuth token, then they will be redirected to the ``login``
+        have an OAuth token, then they will be redirected to the
+        :meth:`~flask_dance.consumer.oauth1.OAuth1ConsumerBlueprint.login`
         view to obtain one.
         """
         def wrapper(func):
@@ -160,7 +161,8 @@ class OAuth2Session(BaseOAuth2Session):
     def authorization_required(self):
         """
         This is a decorator for a view function. If the current user does not
-        have an OAuth token, then they will be redirected to the ``login``
+        have an OAuth token, then they will be redirected to the
+        :meth:`~flask_dance.consumer.oauth2.OAuth2ConsumerBlueprint.login`
         view to obtain one.
         """
         def wrapper(func):


### PR DESCRIPTION
This allows you to decorate views to indicate that the user must have an OAuth token to continue. It should automatically be available on every session proxy, including all the pre-set configurations.