### PR TITLE
add before_login signal to allow custom actions before first redirect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* Add ``oauth_before_login`` signal
 
 `1.3.0`_ (2019-01-14)
 ---------------------

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -64,5 +64,23 @@ The following signals exist in Flask-Dance:
     anyway, so it is your responsibility to hook into this signal and inform
     the user that there was an error.
 
+
+.. data:: oauth_before_login
+
+    This signal is sent before redirecting to the provider login page. The signal
+    is sent with a ``url`` parameter specifying the redirect URL. This signal is mostly
+    useful for doing things like session construction / de-construction before the user
+    is redirected.
+
+    Example subscriber::
+
+        from flask_dance.consumer import oauth_before_login
+
+        @oauth_before_login.connect
+        def before_login(blueprint, url):
+            flask.session["i_was_here_before"] = "the_login"
+            # if "facebook" in url:
+                # do facebook stuff
+
 .. _flash a message: http://flask.pocoo.org/docs/latest/patterns/flashing/
 .. _blinker: http://pythonhosted.org/blinker/

--- a/flask_dance/__init__.py
+++ b/flask_dance/__init__.py
@@ -3,4 +3,4 @@ from __future__ import unicode_literals
 
 from .consumer import OAuth1ConsumerBlueprint, OAuth2ConsumerBlueprint
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/flask_dance/__init__.py
+++ b/flask_dance/__init__.py
@@ -3,4 +3,4 @@ from __future__ import unicode_literals
 
 from .consumer import OAuth1ConsumerBlueprint, OAuth2ConsumerBlueprint
 
-__version__ = "1.3.1"
+__version__ = "1.3.0"

--- a/flask_dance/consumer/__init__.py
+++ b/flask_dance/consumer/__init__.py
@@ -1,4 +1,4 @@
 from .oauth1 import OAuth1ConsumerBlueprint
 from .oauth2 import OAuth2ConsumerBlueprint
-from .base import oauth_authorized, oauth_before_authorized, oauth_error
+from .base import oauth_authorized, oauth_before_login, oauth_error
 from .requests import OAuth1Session, OAuth2Session

--- a/flask_dance/consumer/__init__.py
+++ b/flask_dance/consumer/__init__.py
@@ -1,4 +1,4 @@
 from .oauth1 import OAuth1ConsumerBlueprint
 from .oauth2 import OAuth2ConsumerBlueprint
-from .base import oauth_authorized, oauth_error
+from .base import oauth_authorized, oauth_before_authorized, oauth_error
 from .requests import OAuth1Session, OAuth2Session

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -13,7 +13,7 @@ from flask_dance.utils import getattrd, timestamp_from_datetime
 
 _signals = Namespace()
 oauth_authorized = _signals.signal('oauth-authorized')
-oauth_before_login = _signals.signal('oauth-before-authorized')
+oauth_before_login = _signals.signal('oauth-before-login')
 oauth_error = _signals.signal('oauth-error')
 
 

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -13,7 +13,7 @@ from flask_dance.utils import getattrd, timestamp_from_datetime
 
 _signals = Namespace()
 oauth_authorized = _signals.signal('oauth-authorized')
-oauth_before_authorized = _signals.signal('oauth-before-authorized')
+oauth_before_login = _signals.signal('oauth-before-authorized')
 oauth_error = _signals.signal('oauth-error')
 
 

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -13,6 +13,7 @@ from flask_dance.utils import getattrd, timestamp_from_datetime
 
 _signals = Namespace()
 oauth_authorized = _signals.signal('oauth-authorized')
+oauth_before_authorized = _signals.signal('oauth-before-authorized')
 oauth_error = _signals.signal('oauth-error')
 
 

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -7,7 +7,7 @@ from werkzeug.wrappers import Response
 from requests_oauthlib.oauth1_session import TokenRequestDenied, TokenMissing
 from oauthlib.oauth1 import SIGNATURE_HMAC, SIGNATURE_TYPE_AUTH_HEADER
 from oauthlib.common import to_unicode
-from .base import BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
+from .base import BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_login, oauth_error
 from .requests import OAuth1Session
 
 log = logging.getLogger(__name__)
@@ -181,7 +181,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             return redirect(next_url)
 
         url = self.session.authorization_url(self.authorization_url)
-        oauth_before_authorized.send(self, url=url)
+        oauth_before_login.send(self, url=url)
         return redirect(url)
 
     def authorized(self):

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -7,7 +7,7 @@ from werkzeug.wrappers import Response
 from requests_oauthlib.oauth1_session import TokenRequestDenied, TokenMissing
 from oauthlib.oauth1 import SIGNATURE_HMAC, SIGNATURE_TYPE_AUTH_HEADER
 from oauthlib.common import to_unicode
-from .base import BaseOAuthConsumerBlueprint, oauth_authorized, oauth_error
+from .base import BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
 from .requests import OAuth1Session
 
 log = logging.getLogger(__name__)
@@ -181,6 +181,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             return redirect(next_url)
 
         url = self.session.authorization_url(self.authorization_url)
+        oauth_before_authorized.send(self, url=url)
         return redirect(url)
 
     def authorized(self):

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -8,7 +8,7 @@ from flask import request, url_for, redirect, current_app
 from werkzeug.wrappers import Response
 from oauthlib.oauth2 import MissingCodeError
 from .base import (
-    BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
+    BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_login, oauth_error
 )
 from .requests import OAuth2Session
 
@@ -189,7 +189,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         flask.session[state_key] = state
         log.debug("state = %s", state)
         log.debug("redirect URL = %s", url)
-        oauth_before_authorized.send(self, url=url)
+        oauth_before_login.send(self, url=url)
         return redirect(url)
 
     def authorized(self):

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -8,7 +8,7 @@ from flask import request, url_for, redirect, current_app
 from werkzeug.wrappers import Response
 from oauthlib.oauth2 import MissingCodeError
 from .base import (
-    BaseOAuthConsumerBlueprint, oauth_authorized, oauth_error
+    BaseOAuthConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
 )
 from .requests import OAuth2Session
 
@@ -189,6 +189,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         flask.session[state_key] = state
         log.debug("state = %s", state)
         log.debug("redirect URL = %s", url)
+        oauth_before_authorized.send(self, url=url)
         return redirect(url)
 
     def authorized(self):

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -11,7 +11,7 @@ import responses
 import flask
 from werkzeug.contrib.fixers import ProxyFix
 from flask_dance.consumer import (
-    OAuth1ConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
+    OAuth1ConsumerBlueprint, oauth_authorized, oauth_before_login, oauth_error
 )
 from oauthlib.oauth1.rfc5849.utils import parse_authorization_header
 from flask_dance.consumer.requests import OAuth1Session
@@ -324,15 +324,15 @@ def test_signal_oauth_authorized_abort(request):
 
 
 @requires_blinker
-def test_signal_oauth_before_authorized(request):
+def test_signal_oauth_before_login(request):
     app, bp = make_app()
     bp.session.fetch_request_token = mock.Mock(return_value="test-token")
     def callback(*args, **kwargs):
         flask.session["test"] = "test"
         return False
-    oauth_before_authorized.connect(callback)
+    oauth_before_login.connect(callback)
     request.addfinalizer(
-        lambda: oauth_before_authorized.disconnect(callback))
+        lambda: oauth_before_login.disconnect(callback))
     with app.test_client() as client:
         client.get(
             "/login/test-service",

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -11,7 +11,7 @@ import responses
 import flask
 from werkzeug.contrib.fixers import ProxyFix
 from flask_dance.consumer import (
-    OAuth1ConsumerBlueprint, oauth_authorized, oauth_error
+    OAuth1ConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
 )
 from oauthlib.oauth1.rfc5849.utils import parse_authorization_header
 from flask_dance.consumer.requests import OAuth1Session
@@ -322,6 +322,22 @@ def test_signal_oauth_authorized_abort(request):
     # the callback should still have been called
     assert len(calls) == 1
 
+
+@requires_blinker
+def test_signal_oauth_before_authorized(request):
+    app, bp = make_app()
+    bp.session.fetch_request_token = mock.Mock(return_value="test-token")
+    def callback(*args, **kwargs):
+        flask.session["test"] = "test"
+        return False
+    oauth_before_authorized.connect(callback)
+    request.addfinalizer(
+        lambda: oauth_before_authorized.disconnect(callback))
+    with app.test_client() as client:
+        client.get(
+            "/login/test-service",
+        )
+        assert flask.session["test"] == "test"
 
 @requires_blinker
 def test_signal_oauth_authorized_response(request):

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -457,15 +457,18 @@ def test_signal_oauth_authorized(request):
 def test_signal_oauth_before_login(request):
     app, bp = make_app()
     def callback(*args, **kwargs):
-        flask.session["test"] = "test"
+        del flask.session["user_id"]
     oauth_before_login.connect(callback)
     request.addfinalizer(
         lambda: oauth_before_login.disconnect(callback))
-    with app.test_client() as client:
-        client.get(
-            "/login/test-service",
-        )
-        assert flask.session["test"] == "test"
+    with app.test_request_context():
+        with app.test_client() as client:
+            flask.session["user_id"] = 1
+            assert flask.session["user_id"] == 1
+            client.get(
+                "/login/test-service",
+            )
+            assert "user_id" not in flask.session
 
 @requires_blinker
 def test_signal_oauth_authorized_abort(request):

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -17,7 +17,7 @@ import flask
 from freezegun import freeze_time
 from werkzeug.contrib.fixers import ProxyFix
 from flask_dance.consumer import (
-    OAuth2ConsumerBlueprint, oauth_authorized, oauth_before_authorized, oauth_error
+    OAuth2ConsumerBlueprint, oauth_authorized, oauth_before_login, oauth_error
 )
 from flask_dance.consumer.requests import OAuth2Session
 from flask_dance.consumer.backend import MemoryBackend
@@ -454,13 +454,13 @@ def test_signal_oauth_authorized(request):
 
 
 @requires_blinker
-def test_signal_oauth_before_authorized(request):
+def test_signal_oauth_before_login(request):
     app, bp = make_app()
     def callback(*args, **kwargs):
         flask.session["test"] = "test"
-    oauth_before_authorized.connect(callback)
+    oauth_before_login.connect(callback)
     request.addfinalizer(
-        lambda: oauth_before_authorized.disconnect(callback))
+        lambda: oauth_before_login.disconnect(callback))
     with app.test_client() as client:
         client.get(
             "/login/test-service",


### PR DESCRIPTION
Implement `before_authorized` signal to allow custom methods to run before the initial network redirection (in the `login` method). closes #219.