### PR TITLE
Google OAuth prompt update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changed
 Added
 ~~~~~
 * Add ``oauth_before_login`` signal
+* Add ``reprompt_select_account`` parameter to google blueprint
 
 `1.3.0`_ (2019-01-14)
 ---------------------

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -48,7 +48,6 @@ def make_google_blueprint(
             consent. Defaults to False
         reprompt_select_account (bool): If True, force Google to re-prompt the select account page,
          even if there is a single logged-in user. Defaults to False
-            consent. Defaults to False
         redirect_url (str): the URL to redirect to after the authentication
             dance is complete
         redirect_to (str): if ``redirect_url`` is not defined, the name of the

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -47,7 +47,7 @@ def make_google_blueprint(
             for their consent, even if the user has already given their
             consent. Defaults to False
         reprompt_select_account (bool): If True, force Google to re-prompt the select account page,
-         even if there is a single logged-in user. Defaults to False
+            even if there is a single logged-in user. Defaults to False
         redirect_url (str): the URL to redirect to after the authentication
             dance is complete
         redirect_to (str): if ``redirect_url`` is not defined, the name of the
@@ -116,7 +116,6 @@ def make_google_blueprint(
     if prompt_params:
         prompt_params = " ".join(prompt_params)
         authorization_url_params["prompt"] = prompt_params
-
     if hosted_domain:
         authorization_url_params["hd"] = hosted_domain
     google_bp = OAuth2ConsumerBlueprint(

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -19,6 +19,7 @@ def make_google_blueprint(
     scope=None,
     offline=False,
     reprompt_consent=False,
+    reprompt_select_account=False,
     redirect_url=None,
     redirect_to=None,
     login_url=None,
@@ -44,6 +45,9 @@ def make_google_blueprint(
             for the OAuth token. Defaults to False
         reprompt_consent (bool): If True, force Google to re-prompt the user
             for their consent, even if the user has already given their
+            consent. Defaults to False
+        reprompt_select_account (bool): If True, force Google to re-prompt the select account page,
+         even if there is a single logged-in user. Defaults to False
             consent. Defaults to False
         redirect_url (str): the URL to redirect to after the authentication
             dance is complete
@@ -101,12 +105,19 @@ def make_google_blueprint(
     """
     scope = scope or ["https://www.googleapis.com/auth/userinfo.profile"]
     authorization_url_params = {}
+    prompt_params = []
     auto_refresh_url = None
     if offline:
         authorization_url_params["access_type"] = "offline"
         auto_refresh_url = "https://accounts.google.com/o/oauth2/token"
     if reprompt_consent:
-        authorization_url_params["approval_prompt"] = "force"
+        prompt_params.append("consent")
+    if reprompt_select_account:
+        prompt_params.append("select_account")
+    if prompt_params:
+        prompt_params = " ".join(prompt_params)
+        authorization_url_params["prompt"] = prompt_params
+
     if hosted_domain:
         authorization_url_params["hd"] = hosted_domain
     google_bp = OAuth2ConsumerBlueprint(

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -109,63 +109,99 @@ def test_context_local():
         assert request.headers["Authorization"] == "Bearer app2"
 
 
-@pytest.fixture
-def make_google_blueprint_fixture():
-    def _make_google_blueprint_fixture(**kwargs):
-        app = Flask(__name__)
-        app.secret_key = "backups"
-        goog_bp = make_google_blueprint("foo", "bar", **kwargs)
-        app.register_blueprint(goog_bp)
-
-        with app.test_client() as client:
-            return client.get(
-                "/google",
-                base_url="https://a.b.c",
-                follow_redirects=False,
-            )
-
-    return _make_google_blueprint_fixture
 
 
-def test_offline(make_google_blueprint_fixture):
-    resp = make_google_blueprint_fixture(offline=True)
 
+def test_offline():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint("foo", "bar", offline=True)
+    app.register_blueprint(goog_bp)
+
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
     # check that there is a `access_type=offline` query param in the redirect URL
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["access_type"] == "offline"
 
 
-def test_hd(make_google_blueprint_fixture):
-    resp = make_google_blueprint_fixture(hosted_domain="example.com")
+def test_hd():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint("foo", "bar", hosted_domain="example.com")
+    app.register_blueprint(goog_bp)
 
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
     # check that there is a `hd=example.com` query param in the redirect URL
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["hd"] == "example.com"
 
 
-def test_offline_consent(make_google_blueprint_fixture):
-    resp = make_google_blueprint_fixture(offline=True, reprompt_consent=True)
+def test_offline_consent():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint(
+        "foo", "bar", offline=True, reprompt_consent=True,
+    )
+    app.register_blueprint(goog_bp)
 
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["access_type"] == "offline"
     assert location.query_dict["prompt"] == "consent"
 
 
-def test_offline_select_account(make_google_blueprint_fixture):
-    resp = make_google_blueprint_fixture(offline=True, reprompt_select_account=True)
+def test_offline_select_account():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint(
+        "foo", "bar", offline=True, reprompt_select_account=True,
+    )
+    app.register_blueprint(goog_bp)
 
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["access_type"] == "offline"
     assert location.query_dict["prompt"] == "select_account"
 
 
-def test_offline_select_account_and_consent(make_google_blueprint_fixture):
-    resp = make_google_blueprint_fixture(offline=True, reprompt_consent=True, reprompt_select_account=True)
+def test_offline_select_account_and_consent():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint(
+        "foo", "bar", offline=True, reprompt_consent=True, reprompt_select_account=True,
+    )
+    app.register_blueprint(goog_bp)
 
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["access_type"] == "offline"

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -145,7 +145,7 @@ def test_hd():
     assert location.query_dict["hd"] == "example.com"
 
 
-def test_offline_reprompt():
+def test_offline_consent():
     app = Flask(__name__)
     app.secret_key = "backups"
     goog_bp = make_google_blueprint(
@@ -162,4 +162,44 @@ def test_offline_reprompt():
     assert resp.status_code == 302
     location = URLObject(resp.headers["Location"])
     assert location.query_dict["access_type"] == "offline"
-    assert location.query_dict["approval_prompt"] == "force"
+    assert location.query_dict["prompt"] == "consent"
+
+
+def test_offline_select_account():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint(
+        "foo", "bar", offline=True, reprompt_select_account=True,
+    )
+    app.register_blueprint(goog_bp)
+
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    location = URLObject(resp.headers["Location"])
+    assert location.query_dict["access_type"] == "offline"
+    assert location.query_dict["prompt"] == "select_account"
+
+
+def test_offline_select_account_and_consent():
+    app = Flask(__name__)
+    app.secret_key = "backups"
+    goog_bp = make_google_blueprint(
+        "foo", "bar", offline=True, reprompt_consent=True, reprompt_select_account=True,
+    )
+    app.register_blueprint(goog_bp)
+
+    with app.test_client() as client:
+        resp = client.get(
+            "/google",
+            base_url="https://a.b.c",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    location = URLObject(resp.headers["Location"])
+    assert location.query_dict["access_type"] == "offline"
+    assert location.query_dict["prompt"] == "consent select_account"


### PR DESCRIPTION
Adding the possibility to reprompt the select account page with Google OAuth.

Please see the new documentation for 'prompt' [here](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters)

resolves #227 