### PR TITLE
Consistent config names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* **Backwards incompatible:** All pre-set configurations now use a consistent
+  naming scheme for pulling client IDs and client secrets from the app config.
+  The following configurations have changed: Dropbox, Jira, Meetup, Twitter,
+  and Zoho.
 
 `1.4.0`_ (2019-02-22)
 ---------------------

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -32,7 +32,8 @@ def make_dropbox_blueprint(
     Make a blueprint for authenticating with Dropbox using OAuth 2. This requires
     a client ID and client secret from Dropbox. You should either pass them to
     this constructor, or make sure that your Flask application config defines
-    them, using the variables DROPBOX_OAUTH_APP_KEY and DROPBOX_OAUTH_APP_SECRET.
+    them, using the variables :envvar:`DROPBOX_OAUTH_CLIENT_ID` and
+    :envvar:`DROPBOX_OAUTH_CLIENT_SECRET`.
 
     For more information about the ``force_reapprove``, ``disable_signup``,
     and ``require_role`` arguments, `check the Dropbox API documentation
@@ -94,8 +95,8 @@ def make_dropbox_blueprint(
         backend=backend,
         storage=storage,
     )
-    dropbox_bp.from_config["client_id"] = "DROPBOX_OAUTH_APP_KEY"
-    dropbox_bp.from_config["client_secret"] = "DROPBOX_OAUTH_APP_SECRET"
+    dropbox_bp.from_config["client_id"] = "DROPBOX_OAUTH_CLIENT_ID"
+    dropbox_bp.from_config["client_secret"] = "DROPBOX_OAUTH_CLIENT_SECRET"
 
     @dropbox_bp.before_app_request
     def set_applocal_session():

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -39,8 +39,8 @@ def make_jira_blueprint(
     Make a blueprint for authenticating with JIRA using OAuth 1. This requires
     a consumer key and RSA key for the JIRA application link. You should either
     pass them to this constructor, or make sure that your Flask application
-    config defines them, using the variables JIRA_OAUTH_CONSUMER_KEY and
-    JIRA_OAUTH_RSA_KEY.
+    config defines them, using the variables :envvar:`JIRA_OAUTH_CLIENT_KEY`
+    and :envvar:`JIRA_OAUTH_RSA_KEY`.
 
     Args:
         base_url (str): The base URL of your JIRA installation. For example,
@@ -92,7 +92,7 @@ def make_jira_blueprint(
         backend=backend,
         storage=storage,
     )
-    jira_bp.from_config["client_key"] = "JIRA_OAUTH_CONSUMER_KEY"
+    jira_bp.from_config["client_key"] = "JIRA_OAUTH_CLIENT_KEY"
     jira_bp.from_config["rsa_key"] = "JIRA_OAUTH_RSA_KEY"
 
     @jira_bp.before_app_request

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -29,7 +29,8 @@ def make_meetup_blueprint(
     Make a blueprint for authenticating with Meetup using OAuth 2. This requires
     an OAuth consumer from Meetup. You should either pass the key and secret to
     this constructor, or make sure that your Flask application config defines
-    them, using the variables MEETUP_OAUTH_KEY and MEETUP_OAUTH_SECRET.
+    them, using the variables :envvar:`MEETUP_OAUTH_CLIENT_ID` and
+    :envvar:`MEETUP_OAUTH_CLIENT_SECRET`.
 
     Args:
         key (str): The OAuth consumer key for your application on Meetup
@@ -72,8 +73,8 @@ def make_meetup_blueprint(
         backend=backend,
         storage=storage,
     )
-    meetup_bp.from_config["client_id"] = "MEETUP_OAUTH_KEY"
-    meetup_bp.from_config["client_secret"] = "MEETUP_OAUTH_SECRET"
+    meetup_bp.from_config["client_id"] = "MEETUP_OAUTH_CLIENT_ID"
+    meetup_bp.from_config["client_secret"] = "MEETUP_OAUTH_CLIENT_SECRET"
 
     @meetup_bp.before_app_request
     def set_applocal_session():

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -28,7 +28,8 @@ def make_twitter_blueprint(
     Make a blueprint for authenticating with Twitter using OAuth 1. This requires
     an API key and API secret from Twitter. You should either pass them to
     this constructor, or make sure that your Flask application config defines
-    them, using the variables TWITTER_OAUTH_API_KEY and TWITTER_OAUTH_API_SECRET.
+    them, using the variables :envvar:`TWITTER_OAUTH_CLIENT_KEY` and
+    :envvar:`TWITTER_OAUTH_CLIENT_SECRET`.
 
     Args:
         api_key (str): The API key for your Twitter application
@@ -69,8 +70,8 @@ def make_twitter_blueprint(
         backend=backend,
         storage=storage,
     )
-    twitter_bp.from_config["client_key"] = "TWITTER_OAUTH_API_KEY"
-    twitter_bp.from_config["client_secret"] = "TWITTER_OAUTH_API_SECRET"
+    twitter_bp.from_config["client_key"] = "TWITTER_OAUTH_CLIENT_KEY"
+    twitter_bp.from_config["client_secret"] = "TWITTER_OAUTH_CLIENT_SECRET"
 
     @twitter_bp.before_app_request
     def set_applocal_session():

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -35,7 +35,8 @@ def make_zoho_blueprint(
     Make a blueprint for authenticating with Zoho using OAuth 2. This requires
     a client ID and client secret from Zoho. You should either pass them to
     this constructor, or make sure that your Flask application config defines
-    them, using the variables ZOHO_OAUTH_CLIENT_ID and ZOHO_OAUTH_CLIENT_SECRET.
+    them, using the variables :envvar:`ZOHO_OAUTH_CLIENT_ID` and
+    :envvar:`ZOHO_OAUTH_CLIENT_SECRET`.
     IMPORTANT: Configuring the base_url is not supported in this config.
 
     Args:
@@ -90,10 +91,9 @@ def make_zoho_blueprint(
         backend=backend,
         storage=storage,
     )
-    if not client_id:
-        zoho_bp.from_config["client_id"] = "ZOHO_OAUTH_CLIENT_ID"
-    if not client_secret:
-        zoho_bp.from_config["client_secret"] = "ZOHO_OAUTH_CLIENT_SECRET"
+
+    zoho_bp.from_config["client_id"] = "ZOHO_OAUTH_CLIENT_ID"
+    zoho_bp.from_config["client_secret"] = "ZOHO_OAUTH_CLIENT_SECRET"
 
     @zoho_bp.before_app_request
     def set_applocal_session():

--- a/tests/contrib/test_dropbox.py
+++ b/tests/contrib/test_dropbox.py
@@ -33,8 +33,8 @@ def test_blueprint_factory():
 
 def test_load_from_config(make_app):
     app = make_app()
-    app.config["DROPBOX_OAUTH_APP_KEY"] = "foo"
-    app.config["DROPBOX_OAUTH_APP_SECRET"] = "bar"
+    app.config["DROPBOX_OAUTH_CLIENT_ID"] = "foo"
+    app.config["DROPBOX_OAUTH_CLIENT_SECRET"] = "bar"
 
     resp = app.test_client().get("/dropbox")
     url = resp.headers["Location"]

--- a/tests/contrib/test_jira.py
+++ b/tests/contrib/test_jira.py
@@ -68,7 +68,7 @@ def test_load_from_config(sign_func, make_app):
         body="oauth_token=faketoken&oauth_token_secret=fakesecret",
     )
     app = make_app("https://flask.atlassian.net", redirect_to="index")
-    app.config["JIRA_OAUTH_CONSUMER_KEY"] = "foo"
+    app.config["JIRA_OAUTH_CLIENT_KEY"] = "foo"
     app.config["JIRA_OAUTH_RSA_KEY"] = "bar"
 
     resp = app.test_client().get("/jira")

--- a/tests/contrib/test_meetup.py
+++ b/tests/contrib/test_meetup.py
@@ -34,8 +34,8 @@ def test_blueprint_factory():
 
 def test_load_from_config(make_app):
     app = make_app()
-    app.config["MEETUP_OAUTH_KEY"] = "foo"
-    app.config["MEETUP_OAUTH_SECRET"] = "bar"
+    app.config["MEETUP_OAUTH_CLIENT_ID"] = "foo"
+    app.config["MEETUP_OAUTH_CLIENT_SECRET"] = "bar"
 
     resp = app.test_client().get("/meetup")
     url = resp.headers["Location"]

--- a/tests/contrib/test_twitter.py
+++ b/tests/contrib/test_twitter.py
@@ -42,8 +42,8 @@ def test_load_from_config(make_app):
         body="oauth_token=faketoken&oauth_token_secret=fakesecret",
     )
     app = make_app()
-    app.config["TWITTER_OAUTH_API_KEY"] = "foo"
-    app.config["TWITTER_OAUTH_API_SECRET"] = "bar"
+    app.config["TWITTER_OAUTH_CLIENT_KEY"] = "foo"
+    app.config["TWITTER_OAUTH_CLIENT_SECRET"] = "bar"
 
     app.test_client().get("/twitter")
     auth_header = dict(

--- a/tests/contrib/test_zoho.py
+++ b/tests/contrib/test_zoho.py
@@ -43,18 +43,6 @@ def test_load_from_config(make_app):
 
 
 @responses.activate
-def test_load_from_params(make_app):
-    app = make_app(client_id="not_foo", client_secret="not_bar")
-    app.config["ZOHO_OAUTH_CLIENT_ID"] = "foo"
-    app.config["ZOHO_OAUTH_CLIENT_SECRET"] = "bar"
-
-    resp = app.test_client().get("/zoho")
-    url = resp.headers["Location"]
-    client_id = URLObject(url).query.dict.get("client_id")
-    assert client_id == "not_foo"
-
-
-@responses.activate
 def test_context_local(make_app):
     responses.add(responses.GET, "https://google.com")
     # set up two apps with two different set of auth tokens


### PR DESCRIPTION
Previously, I tried to make the pre-set configurations pull values from the Flask config based on the terminology used on the provider website. For example, Twitter calls the credentials "API Key" and "API Secret", even though the OAuth standard calls them "client key" and "client secret". This resulted in inconsistency across providers.

This pull request makes the pre-set configurations consistent with the OAuth standard.

This is a **backwards-incompatible** change. As such, it should only be merged just before we release Flask-Dance 2.0.