### PR TITLE
Remove `next` redirect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* **Backwards incompatible:** Previously, Flask-Dance had an undocumented
+  feature where it would automatically redirect based on a ``next``
+  parameter in the URL. This undocumented feature has been removed.
 
 `1.4.0`_ (2019-02-22)
 ---------------------

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -172,9 +172,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         lazy.invalidate(self, "session")
 
     def login(self):
-        callback_uri = url_for(
-            ".authorized", next=request.args.get("next"), _external=True
-        )
+        callback_uri = url_for(".authorized", _external=True)
         self.session._client.client.callback_uri = to_unicode(callback_uri)
 
         try:
@@ -187,9 +185,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             log.warning("OAuth 1 request token error: %s", message)
             oauth_error.send(self, message=message, response=response)
             # can't proceed with OAuth, have to just redirect to next_url
-            if "next" in request.args:
-                next_url = request.args["next"]
-            elif self.redirect_url:
+            if self.redirect_url:
                 next_url = self.redirect_url
             elif self.redirect_to:
                 next_url = url_for(self.redirect_to)
@@ -207,9 +203,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         the provider (e.g. Twitter) after the user has logged into the
         provider's website and authorized your app to access their account.
         """
-        if "next" in request.args:
-            next_url = request.args["next"]
-        elif self.redirect_url:
+        if self.redirect_url:
             next_url = self.redirect_url
         elif self.redirect_to:
             next_url = url_for(self.redirect_to)

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -196,9 +196,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
 
     def login(self):
         log.debug("client_id = %s", self.client_id)
-        self.session.redirect_uri = url_for(
-            ".authorized", next=request.args.get("next"), _external=True
-        )
+        self.session.redirect_uri = url_for(".authorized", _external=True)
         url, state = self.session.authorization_url(
             self.authorization_url, state=self.state, **self.authorization_url_params
         )
@@ -215,9 +213,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         the provider (e.g. Twitter) after the user has logged into the
         provider's website and authorized your app to access their account.
         """
-        if "next" in request.args:
-            next_url = request.args["next"]
-        elif self.redirect_url:
+        if self.redirect_url:
             next_url = self.redirect_url
         elif self.redirect_to:
             next_url = url_for(self.redirect_to)
@@ -252,9 +248,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         self.session._state = state
         del flask.session[state_key]
 
-        self.session.redirect_uri = url_for(
-            ".authorized", next=request.args.get("next"), _external=True
-        )
+        self.session.redirect_uri = url_for(".authorized", _external=True)
 
         log.debug("client_id = %s", self.client_id)
         log.debug("client_secret = %s", self.client_secret)


### PR DESCRIPTION
Previously, Flask-Dance had an undocumented feature where it would automatically redirect based on a `next` parameter in the URL. This undocumented feature has been removed.

This is a **backwards incompatible** change. As such, it should only be merged just before we release Flask-Dance 2.0.