### PR TITLE
Update logout.rst

### DIFF
--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -119,8 +119,6 @@ Here's some sample code that works with Google:
             headers={"Content-Type": "application/x-www-form-urlencoded"}
         )
         assert resp.ok, resp.text
-        # delete token from backend
-        blueprint.backend.delete(blueprint)
         logout_user()
         return redirect(somewhere)
 

--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -120,6 +120,8 @@ Here's some sample code that works with Google:
         )
         assert resp.ok, resp.text
         logout_user()
+        # delete token from backend
+        blueprint.backend.delete(blueprint)
         return redirect(somewhere)
 
 After the user uses this method to log out, Google will not remember that they

--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -119,6 +119,8 @@ Here's some sample code that works with Google:
             headers={"Content-Type": "application/x-www-form-urlencoded"}
         )
         assert resp.ok, resp.text
+        # delete token from backend
+        blueprint.backend.delete(blueprint)
         logout_user()
         return redirect(somewhere)
 


### PR DESCRIPTION
The stored token will never be used again so better delete it.
And also when the token is revoked `google.authorized` is still true, and that's unwanted. Deleting the token will make `google.authorized` false.

(at least that's my understanding. Correct me if I'm wrong)