### PR TITLE
Replace lazy dependency with werkzeug.utils.cached_property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 `unreleased`_
 -------------
 
-nothing yet
+* Replace ``lazy`` dependency with
+  `werkzeug.utils.cached_property <http://werkzeug.pocoo.org/docs/0.14/utils/#werkzeug.utils.cached_property>`__
 
 `1.4.0`_ (2019-02-22)
 ---------------------

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -2,11 +2,19 @@ from __future__ import unicode_literals, print_function
 
 from functools import wraps
 from flask import redirect, url_for
-from lazy import lazy
 from urlobject import URLObject
 from requests_oauthlib import OAuth1Session as BaseOAuth1Session
 from requests_oauthlib import OAuth2Session as BaseOAuth2Session
 from oauthlib.common import to_unicode
+from werkzeug.utils import cached_property
+
+try:
+    from werkzeug.utils import invalidate_cached_property
+except ImportError:
+    from werkzeug._internal import _missing
+
+    def invalidate_cached_property(obj, name):
+        obj.__dict__[name] = _missing
 
 
 class OAuth1Session(BaseOAuth1Session):
@@ -28,7 +36,7 @@ class OAuth1Session(BaseOAuth1Session):
         self.blueprint = blueprint
         self.base_url = URLObject(base_url)
 
-    @lazy
+    @cached_property
     def token(self):
         """
         Get and set the values in the OAuth token, structured as a dictionary.
@@ -120,9 +128,9 @@ class OAuth2Session(BaseOAuth2Session):
         super(OAuth2Session, self).__init__(*args, **kwargs)
         self.blueprint = blueprint
         self.base_url = URLObject(base_url)
-        lazy.invalidate(self, "token")
+        invalidate_cached_property(self, "token")
 
-    @lazy
+    @cached_property
     def token(self):
         """
         Get and set the values in the OAuth token, structured as a dictionary.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ requests-oauthlib>=1.0.0
 Flask>=0.7
 urlobject
 six
-lazy


### PR DESCRIPTION
I didn't know about [`werkzeug.utils.cached_property`](http://werkzeug.pocoo.org/docs/0.14/utils/#werkzeug.utils.cached_property) until @daenney [mentioned it](https://github.com/singingwolfboy/flask-dance/issues/231#issuecomment-467408039). Looks like it does _almost_ what we need, except that it's missing the ability to invalidate the cache. [So I added a pull request to do just that.](https://github.com/pallets/werkzeug/pull/1474)

*Maybe* this makes Flask-Dance thread-safe? Could someone please check that?