### PR TITLE
Proposal: call out default `state` variable in docs

### DIFF
--- a/docs/understanding-the-magic.rst
+++ b/docs/understanding-the-magic.rst
@@ -52,6 +52,16 @@ This allows you to access the session within the context of an incoming
 HTTP request, but it will *not* allow you access it outside that
 context.
 
+State & Security
+================
+
+One of the key features of :attr:`~OAuth2ConsumerBlueprint.session` is that 
+the requests it generates use a `state` variable to ensure that the source
+of OAuth authorization callbacks is in fact your intended OAuth provider.
+By default, the state is a random 30-character string, as provided by
+:func:`~oauthlib.common.generate_token`. This protects your app against one
+kind of CSRF attack.
+
 Checking Authorization
 ----------------------
 


### PR DESCRIPTION
This PR is just a suggestion, and I'm sure it could be worded better.

I was trying to verify that Flask-Dance correctly followed the Google OpenID documents ( https://developers.google.com/identity/protocols/OpenIDConnect - see "Authentication URI parameters" -> "state" -> "(Optional, but strongly recommended)" ).

I had a heck of a time tracking down the code path across three packages (flask-dance -> requests_oauth -> oauthlib) to finally find the function where the `state` variable is initialized by default. I couldn't find it documented anywhere, and it struck me as something that should be called out given the "Optional but strongly recommended" call out by Google.

I'm happy to rework this, and would suggest that `nonce` get a callout here as well, perhaps?