### PR TITLE
Will add blinker to list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+blinker>=1.4
 requests>=2.0
 oauthlib
 requests-oauthlib>=1.0.0


### PR DESCRIPTION
Blinker is used in `.travis.yml` oauth tests and in `setup.py`;
 - `extras_require={"sqla": ["sqlalchemy", "sqlalchemy-utils"], "signals": ["blinker"]},`

However, blinker is not installed since it's not part of `requirements.txt` which leads to `AttributeError: '_FakeSignal' object has no attribute 'connect_via'` when using google for oauth.
