### PR TITLE
Fixed issues with Okta blueprint

### DIFF
--- a/flask_dance/contrib/okta.py
+++ b/flask_dance/contrib/okta.py
@@ -14,15 +14,16 @@ __maintainer__ = "Tom Nolan <tomnolan95@gmail.com>"
 
 
 def make_okta_blueprint(
+    base_url,
+    authorization_url=None,
+    token_url=None,
     client_id=None,
     client_secret=None,
-    base_url=None,
     scope=None,
     redirect_url=None,
-    token_url=None,
     redirect_to=None,
     login_url=None,
-    authorization_url=None,
+    authorized_url=None,
     session_class=None,
     storage=None,
 ):
@@ -34,6 +35,9 @@ def make_okta_blueprint(
     :envvar:`OKTA_OAUTH_CLIENT_SECRET`.
 
     Args:
+        base_url (str): The base URL for your Okta configuration.
+        authorization_url (str): The URL used to authenticated with Okta.
+        token_url (str): The URL used to get a token from Okta.
         client_id (str): The client ID for your application on Okta.
         client_secret (str): The client secret for your application on Okta
         scope (list, optional): list of scopes (str) for the OAuth token
@@ -60,18 +64,22 @@ def make_okta_blueprint(
     okta_bp = OAuth2ConsumerBlueprint(
         "okta",
         __name__,
+        authorized_url=authorized_url,
+        authorization_url= authorization_url if authorization_url else 
+                                "{base_url}/authorize".format(base_url=base_url),
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,
         base_url=base_url,
-        token_url=token_url,
-        authorization_url=authorization_url,
+        token_url=token_url if token_url else
+                                "{base_url}/token".format(base_url=base_url),
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,
         session_class=session_class,
         storage=storage,
     )
+
     okta_bp.from_config["client_id"] = "OKTA_OAUTH_CLIENT_ID"
     okta_bp.from_config["client_secret"] = "OKTA_OAUTH_CLIENT_SECRET"
 

--- a/tests/contrib/test_okta.py
+++ b/tests/contrib/test_okta.py
@@ -29,15 +29,13 @@ def test_blueprint_factory():
     okta_bp = make_okta_blueprint(
         client_id="foo",
         client_secret="bar",
-        base_url="https://dev.oktapreview.com",
+        base_url="https://dev.oktapreview.com/oauth2/default/v1",
         scope="openid:email:profile",
         redirect_to="index",
-        authorization_url="https://dev.oktapreview.com/oauth2/default/v1/authorize",
-        token_url="https://dev.oktapreview.com/oauth2/default/v1/token",
     )
     assert isinstance(okta_bp, OAuth2ConsumerBlueprint)
     assert okta_bp.session.scope == "openid:email:profile"
-    assert okta_bp.session.base_url == "https://dev.oktapreview.com"
+    assert okta_bp.session.base_url == "https://dev.oktapreview.com/oauth2/default/v1"
     assert okta_bp.session.client_id == "foo"
     assert okta_bp.client_secret == "bar"
     assert (
@@ -49,13 +47,9 @@ def test_blueprint_factory():
 
 def test_load_from_config(make_app):
     app = make_app(
-        client_id="foo",
-        client_secret="bar",
-        base_url="https://dev.oktapreview.com",
+        base_url="https://dev.oktapreview.com/oauth2/default/v1",
         scope="openid:email:profile",
         redirect_to="index",
-        authorization_url="https://dev.oktapreview.com/oauth2/default/v1/authorize",
-        token_url="https://dev.oktapreview.com/oauth2/default/v1/token",
     )
     app.config["OKTA_OAUTH_CLIENT_ID"] = "foo"
     app.config["OKTA_OAUTH_CLIENT_SECRET"] = "bar"


### PR DESCRIPTION
Finally got around to doing this. Apologies for the delay! Couple of things:

* As per discussion on #263 I've made `base_url` a required field for the blueprint.
* I've also made `authorization_url` and `token_url` required. The reason being that part of that URL is also configurable. In general they look like: <OKTA_BASE_URL>/oauth2/default/v1/{authorize|token} but the 'default' bit here is configuration and can be renamed to whatever you want. I could try come up with a way of trying to have a default value but that's also dependant on what's used for the BASE_URL.

Let me know if there's anything that needs to be changed! Again sorry about the delay, it's been pretty hectic. Also I created a sample app at: [flask-dance-okta](https://github.com/tnolan8/flask-dance-okta), not totally sure where to place that in the doc!