### PR TITLE
Adding Response object explanation to multi-user setup.

### DIFF
--- a/docs/multi-user.rst
+++ b/docs/multi-user.rst
@@ -114,8 +114,10 @@ behavior. To do so, you'll need to hook into the
 Flask-Dance's default behavior comes from storing the OAuth token for you
 automatically. To override the default behavior, write a function that
 subscribes to this signal, handles it the way *you* want,
-and returns ``False``. Returning ``False`` from this signal handler indicates
-to Flask-Dance that it should not try to store the OAuth token for you.
+and returns ``False`` or a ``Response`` object. Returning ``False`` or a ``Response``
+object from this signal handler indicates to Flask-Dance that it should not try to store
+the OAuth token for you. For example, returning a custom redirect like ``flask.redirect()``
+would override the default behaviour.
 
 .. warning::
 


### PR DESCRIPTION
This adds clarification in the multi-user setup part of the documentation on how to override Flask-Dance default behaviour. In my application, I had to redirect the user to a dynamic url after creating his account, however I didn't understand how I could redirect the user and return False from the signal at the same time. I think this clarifies it. 

resolves #270 