### PR TITLE
Add support for Dropbox short-lived offline refresh tokens.

### DIFF
--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -145,6 +145,13 @@ class OAuth2Session(BaseOAuth2Session):
         return self.token and self.token.get("access_token")
 
     @property
+    def refresh_token(self):
+        """
+        Returns the ``refresh_token`` from the OAuth token.
+        """
+        return self.token and self.token.get("refresh_token")
+
+    @property
     def authorized(self):
         """This is the property used when you have a statement in your code
         that reads "if <provider>.authorized:", e.g. "if twitter.authorized:".

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -17,6 +17,7 @@ def make_dropbox_blueprint(
     app_key=None,
     app_secret=None,
     scope=None,
+    offline=False,
     force_reapprove=False,
     disable_signup=False,
     require_role=None,
@@ -42,6 +43,9 @@ def make_dropbox_blueprint(
         app_key (str): The client ID for your application on Dropbox.
         app_secret (str): The client secret for your application on Dropbox
         scope (str, optional): Comma-separated list of scopes for the OAuth token
+        offline (bool): Whether to request `offline access
+            <https://www.dropbox.com/developers/reference/auth-types>`_
+            for the OAuth token. Defaults to False
         force_reapprove (bool): Force the user to approve the app again
             if they've already done so.
         disable_signup (bool): Prevent users from seeing a sign-up link
@@ -69,6 +73,8 @@ def make_dropbox_blueprint(
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
     authorization_url_params = {}
+    if offline:
+        authorization_url_params["token_access_type"] = "offline"
     if force_reapprove:
         authorization_url_params["force_reapprove"] = "true"
     if disable_signup:

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -43,7 +43,7 @@ def make_dropbox_blueprint(
         app_key (str): The client ID for your application on Dropbox.
         app_secret (str): The client secret for your application on Dropbox
         scope (str, optional): Comma-separated list of scopes for the OAuth token
-        offline (bool): Whether to request `offline access
+        offline (bool): Whether to request `offline token access
             <https://www.dropbox.com/developers/reference/auth-types>`_
             for the OAuth token. Defaults to False
         force_reapprove (bool): Force the user to approve the app again


### PR DESCRIPTION
This patch adds support for offline refresh tokens for Dropbox, which will be required beginning September 2021.

https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens
