### PR TITLE
test: Fix codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.1.1
         with:
-          file: ./coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
By default, `coverage run` does not generate a `coverage.xml`, you have to call `coverage xml` for that. Since we're not doing that, `coverage.xml` doesn't exist so we don't end up uploading code coverage.

It turns out however that doing this is unnecessary. The codecov action will do this by itself if it has to, as long as it finds a `.coverage` which coverage.py will write to by default.