### PR TITLE
Drop EoLed Python versions (including python 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.x", "3.x"]
+        python-version: ["3.6", "3.x"]
         database-uri:
           - "postgresql://testuser:testpw@localhost/testdb"
           - "sqlite://"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 `unreleased`_
 -------------
-nothing yet
+* Dropped support for Python 2 and Python 3.5
 
 `3.3.0`_ (2021-02-25)
 ---------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Flask Dance documentation build configuration file, created by
 # sphinx-quickstart on Sat Sep 27 09:47:52 2014.
@@ -208,8 +207,8 @@ latex_documents = [
     (
         "index",
         "FlaskDance.tex",
-        u"Flask Dance Documentation",
-        u"David Baumgold",
+        "Flask Dance Documentation",
+        "David Baumgold",
         "manual",
     )
 ]
@@ -240,7 +239,7 @@ latex_logo = "_static/flask-dance.png"
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("index", "flaskdance", u"Flask Dance Documentation", [u"David Baumgold"], 1)
+    ("index", "flaskdance", "Flask Dance Documentation", ["David Baumgold"], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -256,8 +255,8 @@ texinfo_documents = [
     (
         "index",
         "FlaskDance",
-        u"Flask Dance Documentation",
-        u"David Baumgold",
+        "Flask Dance Documentation",
+        "David Baumgold",
         "FlaskDance",
         "One line description of project.",
         "Miscellaneous",

--- a/flask_dance/__init__.py
+++ b/flask_dance/__init__.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import unicode_literals
-
 from .consumer import OAuth1ConsumerBlueprint, OAuth2ConsumerBlueprint
 
 __version__ = "3.3.0"

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -1,8 +1,5 @@
-from __future__ import unicode_literals, print_function
-
 import warnings
 from datetime import datetime, timedelta
-import six
 from abc import ABCMeta, abstractmethod, abstractproperty
 from werkzeug.datastructures import CallbackDict
 import flask
@@ -21,7 +18,7 @@ oauth_before_login = _signals.signal("oauth-before-login")
 oauth_error = _signals.signal("oauth-error")
 
 
-class BaseOAuthConsumerBlueprint(six.with_metaclass(ABCMeta, flask.Blueprint)):
+class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
     def __init__(
         self,
         name,

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals, print_function
-
 import logging
 from flask import request, url_for, redirect, current_app
 from werkzeug.wrappers import Response

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function
 import json
 
 import logging
@@ -54,7 +53,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         redirect_to=None,
         session_class=None,
         storage=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Most of the constructor arguments are forwarded either to the
@@ -179,7 +178,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             state=self.state,
             blueprint=self,
             base_url=self.base_url,
-            **self.kwargs
+            **self.kwargs,
         )
 
         def token_updater(token):
@@ -200,7 +199,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         url, state = self.session.authorization_url(
             self.authorization_url, state=self.state, **self.authorization_url_params
         )
-        state_key = "{bp.name}_oauth_state".format(bp=self)
+        state_key = f"{self.name}_oauth_state"
         flask.session[state_key] = state
         log.debug("state = %s", state)
         log.debug("redirect URL = %s", url)
@@ -237,7 +236,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             )
             return redirect(next_url)
 
-        state_key = "{bp.name}_oauth_state".format(bp=self)
+        state_key = f"{self.name}_oauth_state"
         if state_key not in flask.session:
             # can't validate state, so redirect back to login view
             log.info("state not found, redirecting user to login")
@@ -257,7 +256,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
                 self.token_url,
                 authorization_response=request.url,
                 client_secret=self.client_secret,
-                **self.token_url_params
+                **self.token_url_params,
             )
         except MissingCodeError as e:
             e.args = (

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals, print_function
-
 from functools import wraps
 from flask import redirect, url_for
 from urlobject import URLObject
@@ -25,7 +23,7 @@ class OAuth1Session(BaseOAuth1Session):
     """
 
     def __init__(self, blueprint=None, base_url=None, *args, **kwargs):
-        super(OAuth1Session, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.blueprint = blueprint
         self.base_url = URLObject(base_url)
 
@@ -63,7 +61,7 @@ class OAuth1Session(BaseOAuth1Session):
         storage/sqla.py).
         """
         self.load_token()
-        return super(OAuth1Session, self).authorized
+        return super().authorized
 
     @property
     def authorization_required(self):
@@ -80,7 +78,7 @@ class OAuth1Session(BaseOAuth1Session):
             @wraps(func)
             def check_authorization(*args, **kwargs):
                 if not self.authorized:
-                    endpoint = "{name}.login".format(name=self.blueprint.name)
+                    endpoint = f"{self.blueprint.name}.login"
                     return redirect(url_for(endpoint))
                 return func(*args, **kwargs)
 
@@ -91,14 +89,14 @@ class OAuth1Session(BaseOAuth1Session):
     def prepare_request(self, request):
         if self.base_url:
             request.url = self.base_url.relative(request.url)
-        return super(OAuth1Session, self).prepare_request(request)
+        return super().prepare_request(request)
 
     def request(
         self, method, url, data=None, headers=None, should_load_token=True, **kwargs
     ):
         if should_load_token:
             self.load_token()
-        return super(OAuth1Session, self).request(
+        return super().request(
             method=method, url=url, data=data, headers=headers, **kwargs
         )
 
@@ -118,7 +116,7 @@ class OAuth2Session(BaseOAuth2Session):
     """
 
     def __init__(self, blueprint=None, base_url=None, *args, **kwargs):
-        super(OAuth2Session, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.blueprint = blueprint
         self.base_url = URLObject(base_url)
         invalidate_cached_property(self, "token")
@@ -161,7 +159,7 @@ class OAuth2Session(BaseOAuth2Session):
         storage/sqla.py).
         """
         self.load_token()
-        return super(OAuth2Session, self).authorized
+        return super().authorized
 
     @property
     def authorization_required(self):
@@ -178,7 +176,7 @@ class OAuth2Session(BaseOAuth2Session):
             @wraps(func)
             def check_authorization(*args, **kwargs):
                 if not self.authorized:
-                    endpoint = "{name}.login".format(name=self.blueprint.name)
+                    endpoint = f"{self.blueprint.name}.login"
                     return redirect(url_for(endpoint))
                 return func(*args, **kwargs)
 
@@ -191,12 +189,12 @@ class OAuth2Session(BaseOAuth2Session):
             url = self.base_url.relative(url)
 
         self.load_token()
-        return super(OAuth2Session, self).request(
+        return super().request(
             method=method,
             url=url,
             data=data,
             headers=headers,
             client_id=self.blueprint.client_id,
             client_secret=self.blueprint.client_secret,
-            **kwargs
+            **kwargs,
         )

--- a/flask_dance/consumer/storage/__init__.py
+++ b/flask_dance/consumer/storage/__init__.py
@@ -1,8 +1,7 @@
-import six
 from abc import ABCMeta, abstractmethod
 
 
-class BaseStorage(six.with_metaclass(ABCMeta)):
+class BaseStorage(metaclass=ABCMeta):
     @abstractmethod
     def get(self, blueprint):
         return None

--- a/flask_dance/consumer/storage/sqla.py
+++ b/flask_dance/consumer/storage/sqla.py
@@ -14,7 +14,7 @@ except ImportError:
     AnonymousUserMixin = None
 
 
-class OAuthConsumerMixin(object):
+class OAuthConsumerMixin:
     """
     A :ref:`SQLAlchemy declarative mixin <sqlalchemy:declarative_mixins>` with
     some suggested columns for a model to store OAuth tokens:
@@ -34,7 +34,7 @@ class OAuthConsumerMixin(object):
 
     @declared_attr
     def __tablename__(cls):
-        return "flask_dance_{}".format(cls.__name__.lower())
+        return f"flask_dance_{cls.__name__.lower()}"
 
     id = Column(Integer, primary_key=True)
     provider = Column(String(50), nullable=False)
@@ -45,9 +45,9 @@ class OAuthConsumerMixin(object):
         parts = []
         parts.append(self.__class__.__name__)
         if self.id:
-            parts.append("id={}".format(self.id))
+            parts.append(f"id={self.id}")
         if self.provider:
-            parts.append('provider="{}"'.format(self.provider))
+            parts.append(f'provider="{self.provider}"')
         return "<{}>".format(" ".join(parts))
 
 

--- a/flask_dance/contrib/atlassian.py
+++ b/flask_dance/contrib/atlassian.py
@@ -4,10 +4,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"

--- a/flask_dance/contrib/authentiq.py
+++ b/flask_dance/contrib/authentiq.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Pieter Ennes <support@authentiq.com>"

--- a/flask_dance/contrib/authentiq.py
+++ b/flask_dance/contrib/authentiq.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
@@ -63,9 +61,9 @@ def make_authentiq_blueprint(
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,
-        base_url="https://{hostname}/".format(hostname=hostname),
-        authorization_url="https://{hostname}/authorize".format(hostname=hostname),
-        token_url="https://{hostname}/token".format(hostname=hostname),
+        base_url=f"https://{hostname}/",
+        authorization_url=f"https://{hostname}/authorize",
+        token_url=f"https://{hostname}/token",
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Steven MARTINS <steven.martins.fr@gmail.com>"

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Michael Abrahamsen <support@conveyor.dev>"

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Michael Delpech <michaeldel@protonmail.com>"

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
@@ -63,11 +61,11 @@ def make_gitlab_blueprint(
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,
-        base_url="https://{hostname}/api/v4/".format(hostname=hostname),
+        base_url=f"https://{hostname}/api/v4/",
         authorization_url="https://{hostname}/oauth/authorize".format(
             hostname=hostname
         ),
-        token_url="https://{hostname}/oauth/token".format(hostname=hostname),
+        token_url=f"https://{hostname}/oauth/token",
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Justin Georgeson <jgeorgeson@lopht.net>"

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/heroku.py
+++ b/flask_dance/contrib/heroku.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from flask_dance.consumer.requests import OAuth2Session
 from functools import partial
@@ -16,7 +14,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 
 class HerokuOAuth2Session(OAuth2Session):
     def __init__(self, api_version, *args, **kwargs):
-        super(HerokuOAuth2Session, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         accept = "application/vnd.heroku+json; version={api_version}".format(
             api_version=api_version
         )

--- a/flask_dance/contrib/heroku.py
+++ b/flask_dance/contrib/heroku.py
@@ -3,10 +3,7 @@ from flask_dance.consumer.requests import OAuth2Session
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os.path
 from urlobject import URLObject
 from oauthlib.oauth1 import SIGNATURE_RSA
@@ -19,7 +17,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 
 class JsonOAuth1Session(OAuth1Session):
     def __init__(self, *args, **kwargs):
-        super(JsonOAuth1Session, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.headers["Content-Type"] = "application/json"
 
 

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -6,10 +6,7 @@ from flask_dance.consumer.requests import OAuth1Session
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/linkedin.py
+++ b/flask_dance/contrib/linkedin.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/linkedin.py
+++ b/flask_dance/contrib/linkedin.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/reddit.py
+++ b/flask_dance/contrib/reddit.py
@@ -4,10 +4,7 @@ from flask.globals import LocalProxy, _lookup_app_object
 
 from flask_dance import __version__ as _flask_dance_version
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 __maintainer__ = "Sergey Storchay <r8@r8.com.ua>"
 

--- a/flask_dance/contrib/reddit.py
+++ b/flask_dance/contrib/reddit.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint, OAuth2Session
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
@@ -14,21 +12,19 @@ except ImportError:
 __maintainer__ = "Sergey Storchay <r8@r8.com.ua>"
 
 
-DEFAULT_USER_AGENT = "Flask-Dance/{version}".format(version=_flask_dance_version)
+DEFAULT_USER_AGENT = f"Flask-Dance/{_flask_dance_version}"
 
 
 class RedditOAuth2Session(OAuth2Session):
     def __init__(self, *args, **kwargs):
-        super(RedditOAuth2Session, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # The Reddit API requires a non-generic user agent
         self.headers["User-Agent"] = self.blueprint.user_agent or DEFAULT_USER_AGENT
 
     def fetch_token(self, *args, **kwargs):
         # Pass client_id to session so it could trigger Basic Auth
-        return super(RedditOAuth2Session, self).fetch_token(
-            client_id=self.blueprint.client_id, *args, **kwargs
-        )
+        return super().fetch_token(client_id=self.blueprint.client_id, *args, **kwargs)
 
 
 def make_reddit_blueprint(

--- a/flask_dance/contrib/salesforce.py
+++ b/flask_dance/contrib/salesforce.py
@@ -4,10 +4,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -3,10 +3,7 @@ from requests_oauthlib.compliance_fixes.slack import slack_compliance_fix
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from requests_oauthlib.compliance_fixes.slack import slack_compliance_fix
 from functools import partial

--- a/flask_dance/contrib/spotify.py
+++ b/flask_dance/contrib/spotify.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/spotify.py
+++ b/flask_dance/contrib/spotify.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "Nick DiRienzo <me@nickdirienzo.com>"

--- a/flask_dance/contrib/strava.py
+++ b/flask_dance/contrib/strava.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth2ConsumerBlueprint, OAuth2Session
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
@@ -16,18 +14,18 @@ except ImportError:
 __maintainer__ = "Jimmy Hedman <jimmy.hedman@gmail.com>"
 
 
-DEFAULT_USER_AGENT = "Flask-Dance/{version}".format(version=_flask_dance_version)
+DEFAULT_USER_AGENT = f"Flask-Dance/{_flask_dance_version}"
 
 
 class StravaOAuth2Session(OAuth2Session):
     def fetch_token(self, *args, **kwargs):
         # Pass client_id to session so it could trigger Basic Auth
-        return super(StravaOAuth2Session, self).fetch_token(
+        return super().fetch_token(
             include_client_id=True,
             method="POST",
             code=request.args.get("code"),
             *args,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/flask_dance/contrib/strava.py
+++ b/flask_dance/contrib/strava.py
@@ -6,10 +6,7 @@ from flask_dance import __version__ as _flask_dance_version
 
 from flask import request
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 __maintainer__ = "Jimmy Hedman <jimmy.hedman@gmail.com>"
 

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from flask_dance.consumer import OAuth1ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -2,10 +2,7 @@ from flask_dance.consumer import OAuth1ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -4,10 +4,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from functools import partial
 from flask.globals import LocalProxy, _lookup_app_object
 
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
+from flask import _app_ctx_stack as stack
 
 __maintainer__ = "Ryan Schaffer <schaffer.ry@gmail.com>"
 

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from oauthlib.oauth2.rfc6749 import tokens
 from oauthlib.oauth2.rfc6749.clients.web_application import WebApplicationClient
 from flask_dance.consumer import OAuth2ConsumerBlueprint

--- a/flask_dance/fixtures/pytest.py
+++ b/flask_dance/fixtures/pytest.py
@@ -42,7 +42,6 @@ with :func:`pytest.mark.usefixtures`, like this:
         assert response.status_code == 200
 
 """
-from __future__ import absolute_import
 
 import pytest
 
@@ -72,7 +71,7 @@ def betamax_record_flask_dance(app, flask_dance_sessions, request):
         betamax_setup_info = [
             (
                 session,
-                "{testname}-{index}".format(testname=request.node.name, index=index),
+                f"{request.node.name}-{index}",
             )
             for index, session in enumerate(flask_dance_sessions)
         ]

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import functools
 from datetime import datetime
 
@@ -31,7 +30,7 @@ except ImportError:
         obj.__dict__[name] = _missing
 
 
-class FakeCache(object):
+class FakeCache:
     """
     An object that mimics just enough of Flask-Caching's API to be compatible
     with our needs, but does nothing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.0
 oauthlib
 requests-oauthlib>=1.0.0
-Flask>=0.7
+Flask>=0.9
 urlobject

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ oauthlib
 requests-oauthlib>=1.0.0
 Flask>=0.7
 urlobject
-six

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import unicode_literals
-
 import sys
 import re
 from setuptools import setup, find_packages
@@ -42,7 +39,7 @@ def get_requirements(path):
 
 
 version = ""
-with open("flask_dance/__init__.py", "r") as fd:
+with open("flask_dance/__init__.py") as fd:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     ).group(1)
@@ -60,6 +57,7 @@ setup(
     author_email="david@davidbaumgold.com",
     url="https://github.com/singingwolfboy/flask-dance",
     packages=find_packages(),
+    python_requires=">=3.6",
     install_requires=get_requirements("requirements.txt"),
     tests_require=get_requirements("tests/requirements.txt"),
     extras_require={"sqla": ["sqlalchemy", "sqlalchemy-utils"], "signals": ["blinker"]},
@@ -71,11 +69,11 @@ setup(
         "Framework :: Flask",
         "Framework :: Pytest",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     zip_safe=False,
 )

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -66,7 +66,7 @@ def app(blueprint, db, request):
     return app
 
 
-class record_queries(object):
+class record_queries:
     """
     A context manager for recording the SQLAlchemy queries that were executed
     in a given context block.

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 try:
     from urllib.parse import quote_plus
 except ImportError:
     from urllib import quote_plus
 import pytest
-import mock
+from unittest import mock
 import responses
 import flask
 from werkzeug.middleware.proxy_fix import ProxyFix

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import json
 import re
 from oauthlib.oauth2 import MissingCodeError
@@ -10,7 +8,7 @@ except ImportError:
     from urllib import quote_plus
     from urlparse import parse_qsl
 import pytest
-import mock
+from unittest import mock
 import responses
 from urlobject import URLObject
 import flask

--- a/tests/consumer/test_requests.py
+++ b/tests/consumer/test_requests.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 import pytest
-import mock
+from unittest import mock
 import responses
 from flask_dance.consumer.requests import OAuth1Session, OAuth2Session
 

--- a/tests/contrib/test_authentiq.py
+++ b/tests/contrib/test_authentiq.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from flask import Flask

--- a/tests/contrib/test_azure.py
+++ b/tests/contrib/test_azure.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from flask import Flask

--- a/tests/contrib/test_digitalocean.py
+++ b/tests/contrib/test_digitalocean.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_discord.py
+++ b/tests/contrib/test_discord.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_dropbox.py
+++ b/tests/contrib/test_dropbox.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_facebook.py
+++ b/tests/contrib/test_facebook.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_github.py
+++ b/tests/contrib/test_github.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_gitlab.py
+++ b/tests/contrib/test_gitlab.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_heroku.py
+++ b/tests/contrib/test_heroku.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_jira.py
+++ b/tests/contrib/test_jira.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals
-
 import pytest
-import mock
+from unittest import mock
 import os
 import tempfile
 import responses
@@ -112,7 +110,7 @@ def test_content_type(sign_func, make_app):
     resp = app.test_client().get("/test")
     headers = responses.calls[0].request.headers
     assert "Content-Type" in headers
-    assert headers["Content-Type"] == "application/json".encode("utf-8")
+    assert headers["Content-Type"] == b"application/json"
 
 
 @responses.activate

--- a/tests/contrib/test_linkedin.py
+++ b/tests/contrib/test_linkedin.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_meetup.py
+++ b/tests/contrib/test_meetup.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_nylas.py
+++ b/tests/contrib/test_nylas.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_reddit.py
+++ b/tests/contrib/test_reddit.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_slack.py
+++ b/tests/contrib/test_slack.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_spotify.py
+++ b/tests/contrib/test_spotify.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_strava.py
+++ b/tests/contrib/test_strava.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/contrib/test_twitter.py
+++ b/tests/contrib/test_twitter.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals
-
 import pytest
-import mock
+from unittest import mock
 import responses
 from flask import Flask
 from flask_dance.contrib.twitter import make_twitter_blueprint, twitter

--- a/tests/contrib/test_zoho.py
+++ b/tests/contrib/test_zoho.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import responses
 from urlobject import URLObject

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 pytest
-mock
 responses
 freezegun
 coverage

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,15 +10,15 @@ def test_first():
     first([1, 1, 3, 4, 5], key=lambda x: x % 2 == 0) == 4
 
 
-class C(object):
+class C:
     d = "foo"
 
 
-class B(object):
+class B:
     C = C
 
 
-class A(object):
+class A:
     B = B
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-sqlite{,-blinker},py34-sqlite{,-blinker},py35-sqlite{,-blinker},py36-sqlite{,-blinker},docs
+envlist = py3{6,7,8,9}-sqlite{,-blinker},docs
 
 [testenv]
 deps=
@@ -11,7 +11,7 @@ setenv=DATABASE_URI=sqlite://
 commands=py.test
 
 [testenv:docs]
-basepython=python3.5
+basepython=python3.6
 skipsdist=True
 deps=-r docs/requirements.txt
 changedir=docs


### PR DESCRIPTION
All python versions older than 3.6 are long dead.
https://endoflife.date/python

Motivation for removing them is quite simple - its just easier to support less python versions and python 3.x line has introduced number of nice features that we can start leveraging (fstrings, type hints among others). You can already see some improvements done by `pyupgrade` in this PR.

Please note just removing them here, thanks to `pip` support for [`python_requires`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) will not break old installations assuming they have a  setuptools>=24.2.0 and pip>=9.0.0 .

1) document the python versions supported in setup.py
2) update tox, github actions config
3) run `pyupgrade --py36-plus`
4) remove `six` package