### PR TITLE
Implemented atlassian blueprint for oauth2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 `unreleased`_
 -------------
 * Add `offline` option to `make_dropbox_blueprint`
+* Added Atlassian pre-set configuration
 
 `3.2.0`_ (2020-11-24)
 ---------------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -11,6 +11,18 @@ to Flask-Dance!
    :local:
    :backlinks: none
 
+Atlassian
+---------
+.. module:: flask_dance.contrib.atlassian
+
+.. autofunction:: make_atlassian_blueprint
+
+.. data:: atlassian
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the Atlassian authentication token loaded (assuming
+    that the user has authenticated with Atlassian at some point in the past).
+
 Authentiq
 ---------
 .. module:: flask_dance.contrib.authentiq

--- a/flask_dance/contrib/atlassian.py
+++ b/flask_dance/contrib/atlassian.py
@@ -10,6 +10,9 @@ except ImportError:
     from flask import _request_ctx_stack as stack
 
 
+__maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"
+
+
 def make_atlassian_blueprint(
     client_id=None,
     client_secret=None,

--- a/flask_dance/contrib/jira_oauth2.py
+++ b/flask_dance/contrib/jira_oauth2.py
@@ -1,0 +1,91 @@
+from functools import partial
+
+from flask.globals import LocalProxy, _lookup_app_object
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+
+
+def make_jira_blueprint(
+    client_id=None,
+    client_secret=None,
+    scope=None,
+    reprompt_consent=False,
+    redirect_url=None,
+    redirect_to=None,
+    login_url=None,
+    authorized_url=None,
+    session_class=None,
+    storage=None,
+):
+    """
+    Make a blueprint for authenticating with Jira using OAuth 2. This requires
+    a client ID and client secret from Jira. You should either pass them to
+    this constructor, or make sure that your Flask application config defines
+    them, using the variables :envvar:`JIRA_OAUTH2_CLIENT_ID` and
+    :envvar:`JIRA_OAUTH2_CLIENT_SECRET`.
+
+    Args:
+        client_id (str): The client ID for your application on Jira.
+        client_secret (str): The client secret for your application on Jira.
+        scope (str, optional): comma-separated list of scopes for the OAuth token.
+        reprompt_consent (bool): If True, force Jira to re-prompt the user
+            for their consent, even if the user has already given their
+            consent. Defaults to False.
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete.
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`.
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/jira``.
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/jira/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        storage: A token storage class, or an instance of a token storage
+                class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+    authorization_url_params = {}
+    if reprompt_consent:
+        authorization_url_params["prompt"] = "consent"
+
+    jira_bp = OAuth2ConsumerBlueprint(
+        "jira",
+        __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url="https://api.atlassian.com/",
+        authorization_url=(
+            "https://auth.atlassian.com/authorize?audience=api.atlassian.com"
+        ),
+        token_url="https://auth.atlassian.com/oauth/token",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        authorization_url_params=authorization_url_params,
+        session_class=session_class,
+        storage=storage,
+    )
+    jira_bp.from_config["client_id"] = "JIRA_OAUTH2_CLIENT_ID"
+    jira_bp.from_config["client_secret"] = "JIRA_OAUTH2_CLIENT_SECRET"
+
+    @jira_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.jira_oauth = jira_bp.session
+
+    return jira_bp
+
+
+jira = LocalProxy(partial(_lookup_app_object, "jira_oauth"))

--- a/tests/contrib/test_atlassian.py
+++ b/tests/contrib/test_atlassian.py
@@ -1,0 +1,107 @@
+from __future__ import unicode_literals
+
+import pytest
+import responses
+from urlobject import URLObject
+from flask import Flask
+from flask_dance.contrib.atlassian import make_atlassian_blueprint, atlassian
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.consumer.storage import MemoryStorage
+
+
+@pytest.fixture
+def make_app():
+    "A callable to create a Flask app with the Atlassian provider"
+
+    def _make_app(*args, **kwargs):
+        app = Flask(__name__)
+        app.secret_key = "whatever"
+        blueprint = make_atlassian_blueprint(*args, **kwargs)
+        app.register_blueprint(blueprint)
+        return app
+
+    return _make_app
+
+
+def test_blueprint_factory():
+    atlassian_bp = make_atlassian_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="read:jira-user",
+        redirect_to="index",
+    )
+    assert isinstance(atlassian_bp, OAuth2ConsumerBlueprint)
+    assert atlassian_bp.session.scope == "read:jira-user"
+    assert atlassian_bp.session.base_url == "https://api.atlassian.com/"
+    assert atlassian_bp.session.client_id == "foo"
+    assert atlassian_bp.client_secret == "bar"
+    assert atlassian_bp.authorization_url == "https://auth.atlassian.com/authorize"
+    assert atlassian_bp.token_url == "https://auth.atlassian.com/oauth/token"
+
+
+def test_load_from_config(make_app):
+    app = make_app(redirect_to="index")
+    app.config["ATLASSIAN_OAUTH_CLIENT_ID"] = "foo"
+    app.config["ATLASSIAN_OAUTH_CLIENT_SECRET"] = "bar"
+
+    resp = app.test_client().get("/atlassian")
+    url = resp.headers["Location"]
+    client_id = URLObject(url).query.dict.get("client_id")
+    assert client_id == "foo"
+
+
+def test_blueprint_factory_scope():
+    atlassian_bp = make_atlassian_blueprint(
+        client_id="foo", client_secret="bar", scope="customscope"
+    )
+    assert atlassian_bp.session.scope == "customscope"
+
+
+@responses.activate
+def test_context_local(make_app):
+    responses.add(responses.GET, "https://atlassian.com")
+
+    # set up two apps with two different set of auth tokens
+    app1 = make_app(
+        "foo1",
+        "bar1",
+        redirect_to="url1",
+        storage=MemoryStorage({"access_token": "app1"}),
+    )
+    app2 = make_app(
+        "foo2",
+        "bar2",
+        redirect_to="url2",
+        storage=MemoryStorage({"access_token": "app2"}),
+    )
+
+    # outside of a request context, referencing functions on the `atlassian`
+    # object will raise an exception
+    with pytest.raises(RuntimeError):
+        atlassian.get("https://atlassian.com")
+
+    # inside of a request context, `atlassian` should be a proxy to the correct
+    # blueprint session
+    with app1.test_request_context("/"):
+        app1.preprocess_request()
+        atlassian.get("https://atlassian.com")
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer app1"
+
+    with app2.test_request_context("/"):
+        app2.preprocess_request()
+        atlassian.get("https://atlassian.com")
+        request = responses.calls[1].request
+        assert request.headers["Authorization"] == "Bearer app2"
+
+
+def test_consent(make_app):
+    app = make_app("foo", "bar", reprompt_consent=True)
+
+    with app.test_client() as client:
+        resp = client.get(
+            "/atlassian", base_url="https://atlassian.com", follow_redirects=False
+        )
+    assert resp.status_code == 302
+    location = URLObject(resp.headers["Location"])
+    assert location.query_dict["prompt"] == "consent"


### PR DESCRIPTION
According to https://www.atlassian.com/migration/faqs#general, Atlassian stopped selling and is going to stop maintaining server products and focus on cloud products which use Oauth2 authentication to allow external applications and services to access Atlassian product APIs.

Please suggest naming changes since there already is jira (oauth1) plugin.