### PR TITLE
Added domain option to Salesforce blueprint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,9 @@ Changelog
 
 `unreleased`_
 -------------
-nothing yet
+* Added `hostname` option to the `make_salesforce_blueprint`
+* Added `is_sandbox` option to the `make_salesforce_blueprint`
+* Changed base url for `make_salesforce_blueprint`
 
 `3.3.0`_ (2021-02-25)
 ---------------------

--- a/flask_dance/contrib/salesforce.py
+++ b/flask_dance/contrib/salesforce.py
@@ -18,6 +18,8 @@ def make_salesforce_blueprint(
     client_secret=None,
     scope=None,
     reprompt_consent=False,
+    hostname=None,
+    is_sandbox=False,
     redirect_url=None,
     redirect_to=None,
     login_url=None,
@@ -39,6 +41,11 @@ def make_salesforce_blueprint(
         reprompt_consent (bool): If True, force Salesforce to re-prompt the user
             for their consent, even if the user has already given their
             consent. Defaults to False.
+        hostname (str, optional): The hostname of your Salesforce instance.
+            By default, Salesforce uses ``login.salesforce.com`` for production
+            instances and ``test.salesforce.com`` for sandboxes.
+        is_sandbox (bool): If hostname is not defined specify whether Salesforce
+            instance is a sandbox. Defaults to False.
         redirect_url (str): the URL to redirect to after the authentication
             dance is complete.
         redirect_to (str): if ``redirect_url`` is not defined, the name of the
@@ -62,15 +69,20 @@ def make_salesforce_blueprint(
     if reprompt_consent:
         authorization_url_params["prompt"] = "consent"
 
+    if not hostname:
+        hostname = "test.salesforce.com" if is_sandbox else "login.salesforce.com"
+
     salesforce_bp = OAuth2ConsumerBlueprint(
         "salesforce",
         __name__,
         client_id=client_id,
         client_secret=client_secret,
         scope=scope,
-        base_url="https://login.salesforce.com/services/oauth2/",
-        authorization_url="https://login.salesforce.com/services/oauth2/authorize",
-        token_url="https://login.salesforce.com/services/oauth2/token",
+        base_url="https://{hostname}/".format(hostname=hostname),
+        authorization_url=(
+            "https://{hostname}/services/oauth2/authorize".format(hostname=hostname)
+        ),
+        token_url="https://{hostname}/services/oauth2/token".format(hostname=hostname),
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/tests/contrib/test_salesforce.py
+++ b/tests/contrib/test_salesforce.py
@@ -24,7 +24,7 @@ def make_app():
     return _make_app
 
 
-def test_blueprint_factory():
+def test_blueprint_factory_default():
     salesforce_bp = make_salesforce_blueprint(
         client_id="foo",
         client_secret="bar",
@@ -33,10 +33,7 @@ def test_blueprint_factory():
     )
     assert isinstance(salesforce_bp, OAuth2ConsumerBlueprint)
     assert salesforce_bp.session.scope == "api"
-    assert (
-        salesforce_bp.session.base_url
-        == "https://login.salesforce.com/services/oauth2/"
-    )
+    assert salesforce_bp.session.base_url == "https://login.salesforce.com/"
     assert salesforce_bp.session.client_id == "foo"
     assert salesforce_bp.client_secret == "bar"
     assert (
@@ -45,6 +42,51 @@ def test_blueprint_factory():
     )
     assert (
         salesforce_bp.token_url == "https://login.salesforce.com/services/oauth2/token"
+    )
+
+
+def test_blueprint_factory_sandbox():
+    salesforce_bp = make_salesforce_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="api",
+        redirect_to="index",
+        is_sandbox=True,
+    )
+    assert isinstance(salesforce_bp, OAuth2ConsumerBlueprint)
+    assert salesforce_bp.session.scope == "api"
+    assert salesforce_bp.session.base_url == "https://test.salesforce.com/"
+    assert salesforce_bp.session.client_id == "foo"
+    assert salesforce_bp.client_secret == "bar"
+    assert (
+        salesforce_bp.authorization_url
+        == "https://test.salesforce.com/services/oauth2/authorize"
+    )
+    assert (
+        salesforce_bp.token_url == "https://test.salesforce.com/services/oauth2/token"
+    )
+
+
+def test_blueprint_factory_custom():
+    salesforce_bp = make_salesforce_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="api",
+        redirect_to="index",
+        hostname="example.my.salesforce.com",
+    )
+    assert isinstance(salesforce_bp, OAuth2ConsumerBlueprint)
+    assert salesforce_bp.session.scope == "api"
+    assert salesforce_bp.session.base_url == "https://example.my.salesforce.com/"
+    assert salesforce_bp.session.client_id == "foo"
+    assert salesforce_bp.client_secret == "bar"
+    assert (
+        salesforce_bp.authorization_url
+        == "https://example.my.salesforce.com/services/oauth2/authorize"
+    )
+    assert (
+        salesforce_bp.token_url
+        == "https://example.my.salesforce.com/services/oauth2/token"
     )
 
 


### PR DESCRIPTION
Right now Salesforce will be working only with the production instance. That change adds the possibility to specify custom domains in the Salesforce blueprint. 

Also changed base URL in the blueprint. It will make easier to use the session in further requests.