### PR TITLE
Send specific kwargs to Oauth2CustomerBlueprint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 * Dropped support for Python 2 and Python 3.5
 * If you are using the SQLAlchemy token storage, this project now depends on
   SQLAlchemy version 1.3.11 and above. `sqlalchemy-utils` is no longer necessary.
+* Add disabling of TLS certificate verification for Gitlab blueprint creation
 
 `3.3.1`_ (2021-03-01)
 ---------------------

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -51,7 +51,7 @@ def make_gitlab_blueprint(
             specify the hostname, default is ``gitlab.com``
         verify_tls_certificates (bool, optional): Specify whether TLS
             certificates should be verified. Set this to ``False`` if
-            certificates fail to validate for self-hosted gitlab instances.
+            certificates fail to validate for self-hosted GitLab instances.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -19,6 +19,7 @@ def make_gitlab_blueprint(
     session_class=None,
     storage=None,
     hostname="gitlab.com",
+    **kwargs,
 ):
     """
     Make a blueprint for authenticating with GitLab using OAuth 2. This requires
@@ -67,6 +68,7 @@ def make_gitlab_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        **kwargs,
     )
     gitlab_bp.from_config["client_id"] = "GITLAB_OAUTH_CLIENT_ID"
     gitlab_bp.from_config["client_secret"] = "GITLAB_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -19,7 +19,7 @@ def make_gitlab_blueprint(
     session_class=None,
     storage=None,
     hostname="gitlab.com",
-    **kwargs,
+    verify_tls_certificates=True,
 ):
     """
     Make a blueprint for authenticating with GitLab using OAuth 2. This requires
@@ -49,6 +49,9 @@ def make_gitlab_blueprint(
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         hostname (str, optional): If using a private instance of GitLab CE/EE,
             specify the hostname, default is ``gitlab.com``
+        verify_tls_certificates (bool, optional): Specify whether TLS
+            certificates should be verified. Set this to ``False`` if
+            certificates fail to validate for self-hosted gitlab instances.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -68,7 +71,7 @@ def make_gitlab_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
-        **kwargs,
+        token_url_params=dict(verify=verify_tls_certificates),
     )
     gitlab_bp.from_config["client_id"] = "GITLAB_OAUTH_CLIENT_ID"
     gitlab_bp.from_config["client_secret"] = "GITLAB_OAUTH_CLIENT_SECRET"

--- a/tests/contrib/test_gitlab.py
+++ b/tests/contrib/test_gitlab.py
@@ -99,3 +99,16 @@ def test_context_local(make_app):
         gitlab.get("https://google.com")
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "Bearer app2"
+
+
+def test_verify_parameter(make_app):
+    app = make_app(
+        "foo",
+        "bar",
+        redirect_to="gitlab.login",
+        storage=MemoryStorage({"access_token": "app"}),
+        verify_tls_certificates=False,
+    )
+    with app.test_request_context("/"):
+        app.preprocess_request()
+        assert not gitlab.blueprint.token_url_params.get("verify", True)


### PR DESCRIPTION
Due to the additional setup in this function, it is preferable to use `make_gitlab_blueprint` instead of creating a `Oauth2CustomerBlueprint` directly. However, in the event of a self-hosted gitlab instance using self-signed certificates, these certificates cannot always be verified and this makes the redirection result in an SSL verification error. Thus, one is unable to use `make_gitlab_blueprint` and must instead use the "raw" `Oauth2CustomerBlueprint` in order to pass `token_url_params=dict(verify=False)`.

This change is to add the ability to forward kwargs from `make_gitlab_blueprint` into `Oauth2CustomerBlueprint` for more customisationof functionality.