### PR TITLE
#357 Add the possibility to add kwargs such as "host" from make*blueprint calls

### DIFF
--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -33,7 +33,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
         login_url=None,
         authorized_url=None,
         storage=None,
-        rule_kwargs=None
+        rule_kwargs=None,
     ):
 
         bp_kwargs = dict(
@@ -58,7 +58,10 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
         rule_kwargs = rule_kwargs or {}
 
         self.add_url_rule(
-            rule=login_url.format(bp=self), endpoint="login", view_func=self.login, **rule_kwargs,
+            rule=login_url.format(bp=self),
+            endpoint="login",
+            view_func=self.login,
+            **rule_kwargs,
         )
         self.add_url_rule(
             rule=authorized_url.format(bp=self),

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -36,6 +36,7 @@ class BaseOAuthConsumerBlueprint(six.with_metaclass(ABCMeta, flask.Blueprint)):
         login_url=None,
         authorized_url=None,
         storage=None,
+        rule_kwargs=None
     ):
 
         bp_kwargs = dict(
@@ -57,14 +58,16 @@ class BaseOAuthConsumerBlueprint(six.with_metaclass(ABCMeta, flask.Blueprint)):
 
         login_url = login_url or "/{bp.name}"
         authorized_url = authorized_url or "/{bp.name}/authorized"
+        rule_kwargs = rule_kwargs or {}
 
         self.add_url_rule(
-            rule=login_url.format(bp=self), endpoint="login", view_func=self.login
+            rule=login_url.format(bp=self), endpoint="login", view_func=self.login, **rule_kwargs,
         )
         self.add_url_rule(
             rule=authorized_url.format(bp=self),
             endpoint="authorized",
             view_func=self.authorized,
+            **rule_kwargs,
         )
 
         if storage is None:

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -53,6 +53,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         redirect_to=None,
         session_class=None,
         storage=None,
+        rule_kwargs=None,
         **kwargs
     ):
         """
@@ -108,6 +109,8 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+            rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+                the login and authorized routes. Defaults to ``None``.
         """
         BaseOAuthConsumerBlueprint.__init__(
             self,
@@ -123,6 +126,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             login_url=login_url,
             authorized_url=authorized_url,
             storage=storage,
+            rule_kwargs=rule_kwargs,
         )
 
         self.base_url = base_url

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -54,6 +54,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         redirect_to=None,
         session_class=None,
         storage=None,
+        rule_kwargs=None,
         **kwargs
     ):
         """
@@ -112,6 +113,8 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+            rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+                the login and authorized routes. Defaults to ``None``.
         """
         BaseOAuthConsumerBlueprint.__init__(
             self,
@@ -127,6 +130,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
             login_url=login_url,
             authorized_url=authorized_url,
             storage=storage,
+            rule_kwargs=rule_kwargs,
         )
 
         self.base_url = base_url

--- a/flask_dance/contrib/authentiq.py
+++ b/flask_dance/contrib/authentiq.py
@@ -24,6 +24,7 @@ def make_authentiq_blueprint(
     session_class=None,
     storage=None,
     hostname="connect.authentiq.io",
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with authentiq using OAuth 2. This requires
@@ -52,7 +53,9 @@ def make_authentiq_blueprint(
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         hostname (str, optional): If using a private instance of authentiq CE/EE,
-            specify the hostname, default is ``connect.authentiq.io``
+            specify the hostname, default is ``connect.authentiq.io``.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -72,6 +75,7 @@ def make_authentiq_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     authentiq_bp.from_config["client_id"] = "AUTHENTIQ_OAUTH_CLIENT_ID"
     authentiq_bp.from_config["client_secret"] = "AUTHENTIQ_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -27,6 +27,7 @@ def make_azure_blueprint(
     prompt=None,
     domain_hint=None,
     login_hint=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Azure AD using OAuth 2. This requires
@@ -74,7 +75,8 @@ def make_azure_blueprint(
             having already extracted the username from a previous sign-in using the
             preferred_username claim.
             Defaults to ``None``
-
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to `None.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -107,6 +109,7 @@ def make_azure_blueprint(
         authorization_url_params=authorization_url_params,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     azure_bp.from_config["client_id"] = "AZURE_OAUTH_CLIENT_ID"
     azure_bp.from_config["client_secret"] = "AZURE_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -71,7 +71,7 @@ def make_azure_blueprint(
             preferred_username claim.
             Defaults to ``None``
         rule_kwargs (dict, optional): Additional arguments that should be passed when adding
-            the login and authorized routes. Defaults to `None.
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -49,7 +49,7 @@ def make_digitalocean_blueprint(
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         rule_kwargs (dict, optional): Additional arguments that should be passed when adding
-            the login and authorized routes. Defaults to `None.
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -23,6 +23,7 @@ def make_digitalocean_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Digital Ocean using OAuth 2.
@@ -52,6 +53,8 @@ def make_digitalocean_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to `None.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -71,6 +74,7 @@ def make_digitalocean_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     digitalocean_bp.from_config["client_id"] = "DIGITALOCEAN_OAUTH_CLIENT_ID"
     digitalocean_bp.from_config["client_secret"] = "DIGITALOCEAN_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -51,7 +51,7 @@ def make_discord_blueprint(
             Defaults to ``consent``, setting it to ``None`` will skip user
             interaction if the application was previously approved.
         rule_kwargs (dict, optional): Additional arguments that should be passed when adding
-            the login and authorized routes. Defaults to `None.
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -23,6 +23,7 @@ def make_discord_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Discord using OAuth 2. This requires
@@ -50,6 +51,8 @@ def make_discord_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to `None.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -70,6 +73,7 @@ def make_discord_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     discord_bp.from_config["client_id"] = "DISCORD_OAUTH_CLIENT_ID"
     discord_bp.from_config["client_secret"] = "DISCORD_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -26,6 +26,7 @@ def make_dropbox_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Dropbox using OAuth 2. This requires
@@ -64,6 +65,8 @@ def make_dropbox_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -92,6 +95,7 @@ def make_dropbox_blueprint(
         authorization_url_params=authorization_url_params,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     dropbox_bp.from_config["client_id"] = "DROPBOX_OAUTH_CLIENT_ID"
     dropbox_bp.from_config["client_secret"] = "DROPBOX_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -24,6 +24,7 @@ def make_facebook_blueprint(
     rerequest_declined_permissions=False,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Facebook using OAuth 2. This requires
@@ -53,6 +54,8 @@ def make_facebook_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -76,6 +79,7 @@ def make_facebook_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     facebook_bp.from_config["client_id"] = "FACEBOOK_OAUTH_CLIENT_ID"
     facebook_bp.from_config["client_secret"] = "FACEBOOK_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -23,6 +23,7 @@ def make_github_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with GitHub using OAuth 2. This requires
@@ -50,6 +51,8 @@ def make_github_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -69,6 +72,7 @@ def make_github_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     github_bp.from_config["client_id"] = "GITHUB_OAUTH_CLIENT_ID"
     github_bp.from_config["client_secret"] = "GITHUB_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -24,6 +24,7 @@ def make_gitlab_blueprint(
     session_class=None,
     storage=None,
     hostname="gitlab.com",
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with GitLab using OAuth 2. This requires
@@ -52,7 +53,9 @@ def make_gitlab_blueprint(
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         hostname (str, optional): If using a private instance of GitLab CE/EE,
-            specify the hostname, default is ``gitlab.com``
+            specify the hostname, default is ``gitlab.com``.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -74,6 +77,7 @@ def make_gitlab_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     gitlab_bp.from_config["client_id"] = "GITLAB_OAUTH_CLIENT_ID"
     gitlab_bp.from_config["client_secret"] = "GITLAB_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -27,6 +27,7 @@ def make_google_blueprint(
     session_class=None,
     storage=None,
     hosted_domain=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Google using OAuth 2. This requires
@@ -66,6 +67,8 @@ def make_google_blueprint(
         hosted_domain (str, optional): The domain of the G Suite user. Used to indicate that the account selection UI
             should be optimized for accounts at this domain. Note that this only provides UI optimization, and requires
             response validation (see warning).
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     .. _google_hosted_domain_warning:
     .. warning::
@@ -109,6 +112,7 @@ def make_google_blueprint(
         authorization_url_params=authorization_url_params,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     google_bp.from_config["client_id"] = "GOOGLE_OAUTH_CLIENT_ID"
     google_bp.from_config["client_secret"] = "GOOGLE_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/heroku.py
+++ b/flask_dance/contrib/heroku.py
@@ -34,6 +34,7 @@ def make_heroku_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Heroku using OAuth 2. This requires
@@ -63,6 +64,8 @@ def make_heroku_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -83,6 +86,7 @@ def make_heroku_blueprint(
         authorized_url=authorized_url,
         session_class=session_class or HerokuOAuth2Session,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     heroku_bp.from_config["client_id"] = "HEROKU_OAUTH_CLIENT_ID"
     heroku_bp.from_config["client_secret"] = "HEROKU_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -33,6 +33,7 @@ def make_jira_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with JIRA using OAuth 1. This requires
@@ -64,6 +65,8 @@ def make_jira_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth1ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -89,6 +92,7 @@ def make_jira_blueprint(
         authorized_url=authorized_url,
         session_class=session_class or JsonOAuth1Session,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     jira_bp.from_config["client_key"] = "JIRA_OAUTH_CONSUMER_KEY"
     jira_bp.from_config["rsa_key"] = "JIRA_OAUTH_RSA_KEY"

--- a/flask_dance/contrib/linkedin.py
+++ b/flask_dance/contrib/linkedin.py
@@ -23,6 +23,7 @@ def make_linkedin_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with LinkedIn using OAuth 2. This requires
@@ -50,6 +51,8 @@ def make_linkedin_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -70,6 +73,7 @@ def make_linkedin_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     linkedin_bp.from_config["client_id"] = "LINKEDIN_OAUTH_CLIENT_ID"
     linkedin_bp.from_config["client_secret"] = "LINKEDIN_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -23,6 +23,7 @@ def make_meetup_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Meetup using OAuth 2. This requires
@@ -50,6 +51,8 @@ def make_meetup_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -71,6 +74,7 @@ def make_meetup_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     meetup_bp.from_config["client_id"] = "MEETUP_OAUTH_CLIENT_ID"
     meetup_bp.from_config["client_secret"] = "MEETUP_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -23,6 +23,7 @@ def make_nylas_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Nylas using OAuth 2. This requires
@@ -52,6 +53,8 @@ def make_nylas_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -72,6 +75,7 @@ def make_nylas_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     nylas_bp.from_config["client_id"] = "NYLAS_OAUTH_CLIENT_ID"
     nylas_bp.from_config["client_secret"] = "NYLAS_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/reddit.py
+++ b/flask_dance/contrib/reddit.py
@@ -43,6 +43,7 @@ def make_reddit_blueprint(
     session_class=None,
     storage=None,
     user_agent=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Reddit using OAuth 2. This requires
@@ -74,7 +75,9 @@ def make_reddit_blueprint(
             class, to use for this blueprint. Defaults to
             :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         user_agent (str, optional): User agent for the requests to Reddit API.
-            Defaults to ``Flask-Dance/{{version}}``
+            Defaults to ``Flask-Dance/{{version}}``.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -100,6 +103,7 @@ def make_reddit_blueprint(
         authorized_url=authorized_url,
         session_class=session_class or RedditOAuth2Session,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
 
     reddit_bp.from_config["client_id"] = "REDDIT_OAUTH_CLIENT_ID"

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -30,6 +30,7 @@ def make_slack_blueprint(
     session_class=None,
     storage=None,
     subdomain=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Slack using OAuth 2. This requires
@@ -59,6 +60,8 @@ def make_slack_blueprint(
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         subdomain (str, optional): the name of the subdomain under which your
             Slack space is accessed. Providing this may improve the login experience.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -83,6 +86,7 @@ def make_slack_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     slack_bp.from_config["client_id"] = "SLACK_OAUTH_CLIENT_ID"
     slack_bp.from_config["client_secret"] = "SLACK_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/spotify.py
+++ b/flask_dance/contrib/spotify.py
@@ -23,6 +23,7 @@ def make_spotify_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Spotify using OAuth 2. This requires
@@ -50,6 +51,8 @@ def make_spotify_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -69,6 +72,7 @@ def make_spotify_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     spotify_bp.from_config["client_id"] = "SPOTIFY_OAUTH_CLIENT_ID"
     spotify_bp.from_config["client_secret"] = "SPOTIFY_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/strava.py
+++ b/flask_dance/contrib/strava.py
@@ -42,6 +42,7 @@ def make_strava_blueprint(
     session_class=None,
     storage=None,
     user_agent=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Strava using OAuth 2. This requires
@@ -71,7 +72,9 @@ def make_strava_blueprint(
             class, to use for this blueprint. Defaults to
             :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         user_agent (str, optional): User agent for the requests to Strava API.
-            Defaults to ``Flask-Dance/{{version}}``
+            Defaults to ``Flask-Dance/{{version}}``.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -93,6 +96,7 @@ def make_strava_blueprint(
         authorized_url=authorized_url,
         session_class=session_class or StravaOAuth2Session,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
 
     strava_bp.from_config["client_id"] = "STRAVA_OAUTH_CLIENT_ID"

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -22,6 +22,7 @@ def make_twitter_blueprint(
     authorized_url=None,
     session_class=None,
     storage=None,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Twitter using OAuth 1. This requires
@@ -48,6 +49,8 @@ def make_twitter_blueprint(
         storage: A token storage class, or an instance of a token storage
                 class, to use for this blueprint. Defaults to
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
 
     :rtype: :class:`~flask_dance.consumer.OAuth1ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -67,6 +70,7 @@ def make_twitter_blueprint(
         authorized_url=authorized_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
     twitter_bp.from_config["client_key"] = "TWITTER_OAUTH_CLIENT_KEY"
     twitter_bp.from_config["client_secret"] = "TWITTER_OAUTH_CLIENT_SECRET"

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -29,6 +29,7 @@ def make_zoho_blueprint(
     session_class=None,
     storage=None,
     reprompt_consent=False,
+    rule_kwargs=None,
 ):
     """
     Make a blueprint for authenticating with Zoho using OAuth 2. This requires
@@ -61,7 +62,10 @@ def make_zoho_blueprint(
             for the OAuth token. Defaults to False
         reprompt_consent (bool): If True, force Zoho to re-prompt the user
             for their consent, even if the user has already given their
-            consent. Defaults to False
+            consent. Defaults to False.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
+
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :ref:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
@@ -88,6 +92,7 @@ def make_zoho_blueprint(
         login_url=login_url,
         session_class=session_class,
         storage=storage,
+        rule_kwargs=rule_kwargs,
     )
 
     zoho_bp.from_config["client_id"] = "ZOHO_OAUTH_CLIENT_ID"

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -574,5 +574,6 @@ def test_rule_kwargs():
     app = flask.Flask(__name__)
     app.secret_key = "secret"
     app.register_blueprint(blueprint, url_prefix="/login")
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("test-service.")]
     assert all(rule.host == "example2.com" for rule in rules)
+    assert len(rules) == 2

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -559,3 +559,23 @@ def test_custom_session_class():
     )
     assert isinstance(bp.session, CustomOAuth1Session)
     assert bp.session.my_attr == "foobar"
+
+
+def test_rule_kwargs():
+    blueprint = OAuth1ConsumerBlueprint(
+        "test-service",
+        __name__,
+        client_key="client_key",
+        client_secret="client_secret",
+        base_url="https://example.com",
+        request_token_url="https://example.com/oauth/request_token",
+        access_token_url="https://example.com/oauth/access_token",
+        authorization_url="https://example.com/oauth/authorize",
+        redirect_to="my_view",
+        rule_kwargs={"host":"example2.com"},
+    )
+    app = flask.Flask(__name__)
+    app.secret_key = "secret"
+    app.register_blueprint(blueprint, url_prefix="/login")
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host == "example2.com" for rule in rules)

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -569,11 +569,15 @@ def test_rule_kwargs():
         access_token_url="https://example.com/oauth/access_token",
         authorization_url="https://example.com/oauth/authorize",
         redirect_to="my_view",
-        rule_kwargs={"host":"example2.com"},
+        rule_kwargs={"host": "example2.com"},
     )
     app = flask.Flask(__name__)
     app.secret_key = "secret"
     app.register_blueprint(blueprint, url_prefix="/login")
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("test-service.")]
+    rules = [
+        rule
+        for rule in app.url_map.iter_rules()
+        if rule.endpoint.startswith("test-service.")
+    ]
     assert all(rule.host == "example2.com" for rule in rules)
     assert len(rules) == 2

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -679,3 +679,23 @@ def test_custom_session_class():
     )
     assert isinstance(bp.session, CustomOAuth2Session)
     assert bp.session.my_attr == "foobar"
+
+
+def test_rule_kwargs():
+    blueprint = OAuth2ConsumerBlueprint(
+        "test-service",
+        __name__,
+        client_id="client_id",
+        client_secret="client_secret",
+        state="random-string",
+        base_url="https://example.com",
+        authorization_url="https://example.com/oauth/authorize",
+        token_url="https://example.com/oauth/access_token",
+        redirect_url="http://mysite.cool/whoa?query=basketball",
+        rule_kwargs={"host":"example2.com"},
+    )
+    app = flask.Flask(__name__)
+    app.secret_key = "secret"
+    app.register_blueprint(blueprint, url_prefix="/login")
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host == "example2.com" for rule in rules)

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -695,5 +695,6 @@ def test_rule_kwargs():
     app = flask.Flask(__name__)
     app.secret_key = "secret"
     app.register_blueprint(blueprint, url_prefix="/login")
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("test-service.")]
     assert all(rule.host == "example2.com" for rule in rules)
+    assert len(rules) == 2

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -690,11 +690,15 @@ def test_rule_kwargs():
         authorization_url="https://example.com/oauth/authorize",
         token_url="https://example.com/oauth/access_token",
         redirect_url="http://mysite.cool/whoa?query=basketball",
-        rule_kwargs={"host":"example2.com"},
+        rule_kwargs={"host": "example2.com"},
     )
     app = flask.Flask(__name__)
     app.secret_key = "secret"
     app.register_blueprint(blueprint, url_prefix="/login")
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("test-service.")]
+    rules = [
+        rule
+        for rule in app.url_map.iter_rules()
+        if rule.endpoint.startswith("test-service.")
+    ]
     assert all(rule.host == "example2.com" for rule in rules)
     assert len(rules) == 2

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -82,6 +82,7 @@ def test_blueprint_factory_rule_kwargs(make_app):
     )
     rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
     assert all(rule.host == "example2.com" for rule in rules)
+    assert len(rules) == 2
 
 
 def test_blueprint_factory_no_rule_kwargs(make_app):
@@ -92,6 +93,7 @@ def test_blueprint_factory_no_rule_kwargs(make_app):
     )
     rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
     assert all(rule.host is None for rule in rules)
+    assert len(rules) == 2
 
 
 @responses.activate

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -78,9 +78,11 @@ def test_blueprint_factory_rule_kwargs(make_app):
         client_id="foo",
         client_secret="bar",
         redirect_to="index",
-        rule_kwargs={"host":"example2.com"},
+        rule_kwargs={"host": "example2.com"},
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [
+        rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")
+    ]
     assert all(rule.host == "example2.com" for rule in rules)
     assert len(rules) == 2
 
@@ -91,7 +93,9 @@ def test_blueprint_factory_no_rule_kwargs(make_app):
         client_secret="bar",
         redirect_to="index",
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [
+        rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")
+    ]
     assert all(rule.host is None for rule in rules)
     assert len(rules) == 2
 

--- a/tests/contrib/test_google.py
+++ b/tests/contrib/test_google.py
@@ -75,6 +75,27 @@ def test_blueprint_factory_hosted_domain():
     assert google_bp.authorization_url_params["hd"] == "example.com"
 
 
+def test_blueprint_factory_rule_kwargs(make_app):
+    app = make_app(
+        client_id="foo",
+        client_secret="bar",
+        redirect_to="index",
+        rule_kwargs={"host":"example2.com"},
+    )
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host == "example2.com" for rule in rules)
+
+
+def test_blueprint_factory_no_rule_kwargs(make_app):
+    app = make_app(
+        client_id="foo",
+        client_secret="bar",
+        redirect_to="index",
+    )
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host is None for rule in rules)
+
+
 @responses.activate
 def test_context_local(make_app):
     responses.add(responses.GET, "https://google.com")

--- a/tests/contrib/test_jira.py
+++ b/tests/contrib/test_jira.py
@@ -54,16 +54,18 @@ def test_blueprint_factory_rule_kwargs(make_app):
         redirect_to="index",
         rule_kwargs={"host":"example2.com"},
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")]
     assert all(rule.host == "example2.com" for rule in rules)
+    assert len(rules) == 2
 
 
 def test_blueprint_factory_no_rule_kwargs(make_app):
     app = make_app("https://flask.atlassian.net",
         redirect_to="index",
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")]
     assert all(rule.host is None for rule in rules)
+    assert len(rules) == 2
 
 
 def test_rsa_key_file(tmp_path):

--- a/tests/contrib/test_jira.py
+++ b/tests/contrib/test_jira.py
@@ -51,6 +51,23 @@ def test_blueprint_factory():
     )
 
 
+def test_blueprint_factory_rule_kwargs(make_app):
+    app = make_app("https://flask.atlassian.net",
+        redirect_to="index",
+        rule_kwargs={"host":"example2.com"},
+    )
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host == "example2.com" for rule in rules)
+
+
+def test_blueprint_factory_no_rule_kwargs(make_app):
+    app = make_app("https://flask.atlassian.net",
+        redirect_to="index",
+    )
+    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("google.")]
+    assert all(rule.host is None for rule in rules)
+
+
 def test_rsa_key_file(tmp_path):
     rsa_key = tmp_path / "fake.key"
     rsa_key.write_text("my-fake-key")

--- a/tests/contrib/test_jira.py
+++ b/tests/contrib/test_jira.py
@@ -50,20 +50,26 @@ def test_blueprint_factory():
 
 
 def test_blueprint_factory_rule_kwargs(make_app):
-    app = make_app("https://flask.atlassian.net",
+    app = make_app(
+        "https://flask.atlassian.net",
         redirect_to="index",
-        rule_kwargs={"host":"example2.com"},
+        rule_kwargs={"host": "example2.com"},
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")]
+    rules = [
+        rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")
+    ]
     assert all(rule.host == "example2.com" for rule in rules)
     assert len(rules) == 2
 
 
 def test_blueprint_factory_no_rule_kwargs(make_app):
-    app = make_app("https://flask.atlassian.net",
+    app = make_app(
+        "https://flask.atlassian.net",
         redirect_to="index",
     )
-    rules = [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")]
+    rules = [
+        rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("jira.")
+    ]
     assert all(rule.host is None for rule in rules)
     assert len(rules) == 2
 


### PR DESCRIPTION
Having a multi-tenant site (based on the host name) requires that you use the "host" on the rule (by passing the "host" parameter to the add_url_rule call).  Secondly your Flask app needs to set host_matching to True and set static_host to the "main" host.  There are additional tricks around this, but the answer at https://stackoverflow.com/questions/51883773/flask-app-that-routes-to-multiple-top-level-and-sub-domains given a good indication of what is required.

Currently in flask-dance these rules are created from within BaseOAuthConsumerBlueprint in a rather hard-coded manner with no possibility to add parameters such as "host".

To pass in additional parameters, each make_*_blueprint is now able to take additional parameters (in the form of the rule_kwargs dict) and pass them down (via OAuth2ConsumerBlueprint or OAuth1ConsumerBlueprint).  Ultimately BaseOAuthConsumerBlueprint takes the additional parameter and adds them, defaulting to not adding any parameters if none were provided.

Unittests for Jira (and OAuth1) and Google (and OAuth2) and have been added to ensure the host can be set correctly.  

Parameters have been documented.