### PR TITLE
use keyword-only arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
   pre-set configurations have been updated to also accept a `rule_kwargs` parameter
   as well.
 * Minimum supported version of Flask is now 1.0.4.
+* The blueprint classes and the pre-set configurations now use keyword-only arguments,
+  as defined in `PEP-3102`_.
 
 `4.0.0`_ (2021-04-10)
 ---------------------
@@ -352,6 +354,7 @@ Fixed
 * Initial release
 
 .. _Betamax: https://betamax.readthedocs.io/
+.. _PEP-3012: https://www.python.org/dev/peps/pep-3102/
 .. _issue 53: https://github.com/singingwolfboy/flask-dance/issues/53
 .. _issue 149: https://github.com/singingwolfboy/flask-dance/issues/149
 .. _#143: https://github.com/singingwolfboy/flask-dance/issues/143

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -23,6 +23,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
         self,
         name,
         import_name,
+        *,
         static_folder=None,
         static_url_path=None,
         template_folder=None,

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -29,6 +29,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         import_name,
         client_key=None,
         client_secret=None,
+        *,
         signature_method=SIGNATURE_HMAC,
         signature_type=SIGNATURE_TYPE_AUTH_HEADER,
         rsa_key=None,

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -30,6 +30,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
         import_name,
         client_id=None,
         client_secret=None,
+        *,
         client=None,
         auto_refresh_url=None,
         auto_refresh_kwargs=None,

--- a/flask_dance/contrib/atlassian.py
+++ b/flask_dance/contrib/atlassian.py
@@ -11,6 +11,7 @@ __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"
 def make_atlassian_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     reprompt_consent=False,
     redirect_url=None,

--- a/flask_dance/contrib/authentiq.py
+++ b/flask_dance/contrib/authentiq.py
@@ -11,6 +11,7 @@ __maintainer__ = "Pieter Ennes <support@authentiq.com>"
 def make_authentiq_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope="openid profile",
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -11,6 +11,7 @@ __maintainer__ = "Steven MARTINS <steven.martins.fr@gmail.com>"
 def make_azure_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -11,6 +11,7 @@ __maintainer__ = "Michael Abrahamsen <support@conveyor.dev>"
 def make_digitalocean_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -11,6 +11,7 @@ __maintainer__ = "Michael Delpech <michaeldel@protonmail.com>"
 def make_discord_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_dropbox_blueprint(
     app_key=None,
     app_secret=None,
+    *,
     scope=None,
     offline=False,
     force_reapprove=False,

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -11,6 +11,7 @@ __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
 def make_facebook_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_github_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -18,6 +18,7 @@ class NoVerifyOAuth2Session(OAuth2Session):
 def make_gitlab_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_google_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     offline=False,
     reprompt_consent=False,

--- a/flask_dance/contrib/heroku.py
+++ b/flask_dance/contrib/heroku.py
@@ -19,6 +19,7 @@ class HerokuOAuth2Session(OAuth2Session):
 def make_heroku_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     api_version="3",
     redirect_url=None,

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -22,6 +22,7 @@ def make_jira_blueprint(
     base_url,
     consumer_key=None,
     rsa_key=None,
+    *,
     redirect_url=None,
     redirect_to=None,
     login_url=None,

--- a/flask_dance/contrib/linkedin.py
+++ b/flask_dance/contrib/linkedin.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_linkedin_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_meetup_blueprint(
     key=None,
     secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_nylas_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope="email",
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/reddit.py
+++ b/flask_dance/contrib/reddit.py
@@ -27,6 +27,7 @@ class RedditOAuth2Session(OAuth2Session):
 def make_reddit_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope="identity",
     permanent=False,
     redirect_url=None,

--- a/flask_dance/contrib/salesforce.py
+++ b/flask_dance/contrib/salesforce.py
@@ -11,6 +11,7 @@ __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"
 def make_salesforce_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     reprompt_consent=False,
     hostname=None,

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -17,6 +17,7 @@ class SlackBlueprint(OAuth2ConsumerBlueprint):
 def make_slack_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/spotify.py
+++ b/flask_dance/contrib/spotify.py
@@ -11,6 +11,7 @@ __maintainer__ = "Nick DiRienzo <me@nickdirienzo.com>"
 def make_spotify_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/strava.py
+++ b/flask_dance/contrib/strava.py
@@ -29,6 +29,7 @@ class StravaOAuth2Session(OAuth2Session):
 def make_strava_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope="read",
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/twitch.py
+++ b/flask_dance/contrib/twitch.py
@@ -25,6 +25,7 @@ class ClientIdHeaderOAuth2Session(OAuth2Session):
 def make_twitch_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     redirect_to=None,

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -11,6 +11,7 @@ __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 def make_twitter_blueprint(
     api_key=None,
     api_secret=None,
+    *,
     redirect_url=None,
     redirect_to=None,
     login_url=None,

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -17,6 +17,7 @@ ZOHO_TOKEN_HEADER = "Zoho-oauthtoken"
 def make_zoho_blueprint(
     client_id=None,
     client_secret=None,
+    *,
     scope=None,
     redirect_url=None,
     offline=False,


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-3102/. I intended to use this feature when I first created this library, but Python 2.7 compatibility prevented me from doing so, and I forgot about it until recently. Since this has the potential of causing backwards-incompatibility, we will need to bump the major version number.

@daenney, do you have any thoughts about this change?