### PR TITLE
install specific Flask version for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install specific Flask version
-        if: ${{ matrix.flask-version }} != 'latest'
+        if: ${{ matrix.flask-version != 'latest' }}
         run: pip install Flask==${{ matrix.flask-version }}
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.x"]
+        flask-version: ["1.0.4", "latest"]
         database-uri:
           - "postgresql://testuser:testpw@localhost/testdb"
           - "sqlite://"
-    name: "pytest: Python ${{ matrix.python-version }}, postgres=${{ contains(matrix.database-uri, 'postgres') }}"
+    name: "pytest: Python ${{ matrix.python-version }}, Flask ${{ matrix.flask-version }}, postgres=${{ contains(matrix.database-uri, 'postgres') }}"
     services:
       postgres:
         image: postgres:latest
@@ -39,6 +40,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install specific Flask version
+        if: ${{ matrix.flask-version }} != 'latest'
+        run: pip install Flask==${{ matrix.flask-version }}
 
       - name: Install dependencies
         run: >-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
   you to configure how the OAuth routes are configured. All of the
   pre-set configurations have been updated to also accept a `rule_kwargs` parameter
   as well.
+* Minimum supported version of Flask is now 1.0.4.
 
 `4.0.0`_ (2021-04-10)
 ---------------------

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -47,10 +47,6 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
             url_defaults=url_defaults,
             root_path=root_path,
         )
-        # `root_path` didn't exist in 0.10, and will cause an error if it's
-        # passed in that version. Only pass `root_path` if it's set.
-        if bp_kwargs["root_path"] is None:
-            del bp_kwargs["root_path"]
         flask.Blueprint.__init__(self, **bp_kwargs)
 
         login_url = login_url or "/{bp.name}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.0
 oauthlib
 requests-oauthlib>=1.0.0
-Flask>=0.9
+Flask>=1.0.4
 urlobject


### PR DESCRIPTION
We should verify that we _actually_ support the lowest version of Flask that we claim to support. That means running the automated tests with that version.

I discovered that the latest version of `pytest` doesn't run with Flask 0.7 anymore, which is why I'm bumping up the minimum supported version to Flask 1.0.4. I believe this is due to [this Flask pull request](https://github.com/pallets/flask/issues/3275).

Since we are changing the minimum version of Flask that we support, this will require a major version bump.