### PR TITLE
fix tests and adjust dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.x"]
-        flask-version: ["1.0.4", "latest"]
+        python-version: ["3.7", "3.x"]
+        flask-version: ["2.0.3", "latest"]
         database-uri:
           - "postgresql://testuser:testpw@localhost/testdb"
           - "sqlite://"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.0
 oauthlib
 requests-oauthlib>=1.0.0
-Flask>=1.0.4
-Werkzeug<2.1
+Flask>=2.0.3
+Werkzeug
 urlobject

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -114,7 +114,10 @@ def test_sqla_storage_without_user(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 2
 
@@ -194,7 +197,10 @@ def test_sqla_storage(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 3
 
@@ -332,7 +338,10 @@ def test_sqla_flask_login(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 4
 
@@ -357,7 +366,10 @@ def test_sqla_flask_login(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 4
 
@@ -702,7 +714,10 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 2
 
@@ -747,7 +762,10 @@ def test_sqla_cache(app, db, blueprint, request):
             )
             # check that we redirected the client
             assert resp.status_code == 302
-            assert resp.headers["Location"] == "https://a.b.c/oauth_done"
+            assert resp.headers["Location"] in (
+                "https://a.b.c/oauth_done",
+                "/oauth_done",
+            )
 
     assert len(queries) == 2
 

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -137,7 +137,7 @@ def test_authorized_url():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
         # check that we obtained an access token
         assert len(responses.calls) == 1
         assert "Authorization" in responses.calls[0].request.headers
@@ -222,7 +222,7 @@ def test_redirect_to():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/blargl"
+        assert resp.headers["Location"] in ("https://a.b.c/blargl", "/blargl")
 
 
 @responses.activate
@@ -253,7 +253,7 @@ def test_redirect_fallback():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
 
 
 def test_authorization_required_decorator_allowed():
@@ -287,7 +287,10 @@ def test_authorization_required_decorator_redirect():
         resp = client.get("/restricted", base_url="https://a.b.c")
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/login/test-service"
+        assert resp.headers["Location"] in (
+            "https://a.b.c/login/test-service",
+            "/login/test-service",
+        )
 
 
 @requires_blinker

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -132,7 +132,7 @@ def test_authorized_url():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
         # check that we obtained an access token
         assert len(responses.calls) == 1
         request_data = dict(parse_qsl(responses.calls[0].request.body))
@@ -159,7 +159,10 @@ def test_authorized_url_no_state():
         )
         # check that we redirected the client back to login view
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/login/test-service"
+        assert resp.headers["Location"] in (
+            "https://a.b.c/login/test-service",
+            "/login/test-service",
+        )
         # check that there's nothing in the session
         with client.session_transaction() as sess:
             assert "test-service_oauth_token" not in sess
@@ -234,7 +237,7 @@ def test_authorized_url_token_lifetime():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
         # check that we obtained an access token
         assert len(responses.calls) == 1
         request_data = dict(parse_qsl(responses.calls[0].request.body))
@@ -300,7 +303,7 @@ def test_provider_error():
         )
         # even though there was an error, we should still redirect the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
         # shouldn't even try getting an access token, though
         assert len(responses.calls) == 0
 
@@ -378,7 +381,7 @@ def test_redirect_to():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/blargl"
+        assert resp.headers["Location"] in ("https://a.b.c/blargl", "/blargl")
 
 
 @responses.activate
@@ -417,7 +420,7 @@ def test_redirect_fallback():
         )
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/"
+        assert resp.headers["Location"] in ("https://a.b.c/", "/")
 
 
 def test_authorization_required_decorator_allowed():
@@ -449,7 +452,10 @@ def test_authorization_required_decorator_redirect():
         resp = client.get("/restricted", base_url="https://a.b.c")
         # check that we redirected the client
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "https://a.b.c/login/test-service"
+        assert resp.headers["Location"] in (
+            "https://a.b.c/login/test-service",
+            "/login/test-service",
+        )
 
 
 @requires_blinker


### PR DESCRIPTION
[Flask 2.1.0 has the following changelog entry](https://flask.palletsprojects.com/en/2.1.x/changes/#version-2-1-0):

> From Werkzeug, for redirect responses the Location header URL will remain relative, and exclude the scheme and domain, by default.

This fixes the tests to account for that. In the process of doing so, I discovered that older versions of Flask no longer install and run correctly, due to unconstrained dependency definitions. As a result, this project will no longer support those versions of Flask.