### PR TITLE
use `del obj.name` as invalidate_cached_property is deprecated

### DIFF
--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -8,7 +8,6 @@ from flask_dance.consumer.storage.session import SessionStorage
 from flask_dance.utils import (
     getattrd,
     timestamp_from_datetime,
-    invalidate_cached_property,
 )
 
 
@@ -79,7 +78,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
 
         def invalidate_token(d):
             try:
-                invalidate_cached_property(self.session, "token")
+                del self.session.token
             except KeyError:
                 pass
 
@@ -155,7 +154,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
             _token["expires_at"] = timestamp_from_datetime(expires_at)
         self.storage.set(self, _token)
         try:
-            invalidate_cached_property(self.session, "token")
+            del self.session.token
         except KeyError:
             pass
 
@@ -163,7 +162,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
     def token(self):
         self.storage.delete(self)
         try:
-            invalidate_cached_property(self.session, "token")
+            del self.session.token
         except KeyError:
             pass
 

--- a/flask_dance/consumer/oauth1.py
+++ b/flask_dance/consumer/oauth1.py
@@ -12,7 +12,6 @@ from .base import (
     oauth_error,
 )
 from .requests import OAuth1Session
-from flask_dance.utils import invalidate_cached_property
 
 
 log = logging.getLogger(__name__)
@@ -173,7 +172,7 @@ class OAuth1ConsumerBlueprint(BaseOAuthConsumerBlueprint):
 
     def teardown_session(self, exception=None):
         try:
-            invalidate_cached_property(self, "session")
+            del self.session
         except KeyError:
             pass
 

--- a/flask_dance/consumer/oauth2.py
+++ b/flask_dance/consumer/oauth2.py
@@ -13,7 +13,6 @@ from .base import (
     oauth_error,
 )
 from .requests import OAuth2Session
-from flask_dance.utils import invalidate_cached_property
 
 
 log = logging.getLogger(__name__)
@@ -197,7 +196,7 @@ class OAuth2ConsumerBlueprint(BaseOAuthConsumerBlueprint):
 
     def teardown_session(self, exception=None):
         try:
-            invalidate_cached_property(self, "session")
+            del self.session
         except KeyError:
             pass
 

--- a/flask_dance/consumer/requests.py
+++ b/flask_dance/consumer/requests.py
@@ -5,7 +5,6 @@ from requests_oauthlib import OAuth1Session as BaseOAuth1Session
 from requests_oauthlib import OAuth2Session as BaseOAuth2Session
 from oauthlib.common import to_unicode
 from werkzeug.utils import cached_property
-from flask_dance.utils import invalidate_cached_property
 
 
 class OAuth1Session(BaseOAuth1Session):
@@ -119,7 +118,7 @@ class OAuth2Session(BaseOAuth2Session):
         super().__init__(*args, **kwargs)
         self.blueprint = blueprint
         self.base_url = URLObject(base_url)
-        invalidate_cached_property(self, "token")
+        del self.token
 
     @cached_property
     def token(self):

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -21,14 +21,6 @@ except ImportError:
 
     utc = UTC()
 
-try:
-    from werkzeug.utils import invalidate_cached_property
-except ImportError:
-    from werkzeug._internal import _missing
-
-    def invalidate_cached_property(obj, name):
-        obj.__dict__[name] = _missing
-
 
 class FakeCache:
     """


### PR DESCRIPTION
This is #375 rebased onto the latest `main` branch.