### PR TITLE
Drop py2 imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,2 @@
 [run]
 source = flask_dance
-
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # We only check for ImportError for backwards-compatible imports
-    except ImportError:

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -1,5 +1,4 @@
-import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from abc import ABCMeta, abstractmethod, abstractproperty
 from werkzeug.datastructures import CallbackDict
 import flask
@@ -7,7 +6,6 @@ from flask.signals import Namespace
 from flask_dance.consumer.storage.session import SessionStorage
 from flask_dance.utils import (
     getattrd,
-    timestamp_from_datetime,
 )
 
 
@@ -151,7 +149,7 @@ class BaseOAuthConsumerBlueprint(flask.Blueprint, metaclass=ABCMeta):
             # that may already be there.
             delta = timedelta(seconds=_token["expires_in"])
             expires_at = datetime.utcnow() + delta
-            _token["expires_at"] = timestamp_from_datetime(expires_at)
+            _token["expires_at"] = expires_at.replace(tzinfo=timezone.utc).timestamp()
         self.storage.set(self, _token)
         try:
             del self.session.token

--- a/flask_dance/consumer/base.py
+++ b/flask_dance/consumer/base.py
@@ -4,9 +4,7 @@ from werkzeug.datastructures import CallbackDict
 import flask
 from flask.signals import Namespace
 from flask_dance.consumer.storage.session import SessionStorage
-from flask_dance.utils import (
-    getattrd,
-)
+from flask_dance.utils import getattrd
 
 
 _signals = Namespace()

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,7 +1,6 @@
 import functools
 
 
-
 class FakeCache:
     """
     An object that mimics just enough of Flask-Caching's API to be compatible
@@ -48,4 +47,3 @@ def getattrd(obj, name, default=sentinel):
         if default is not sentinel:
             return default
         raise
-

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,25 +1,5 @@
 import functools
-from datetime import datetime
 
-
-try:
-    from datetime import timezone
-
-    utc = timezone.utc
-except ImportError:
-    from datetime import timedelta, tzinfo
-
-    class UTC(tzinfo):
-        def utcoffset(self, dt):
-            return timedelta(0)
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dst):
-            return timedelta(0)
-
-    utc = UTC()
 
 
 class FakeCache:
@@ -69,15 +49,3 @@ def getattrd(obj, name, default=sentinel):
             return default
         raise
 
-
-def timestamp_from_datetime(dt):
-    """
-    Given a datetime, in UTC, return a float that represents the timestamp for
-    that datetime.
-
-    http://stackoverflow.com/questions/8777753/converting-datetime-date-to-utc-timestamp-in-python#8778548
-    """
-    dt = dt.replace(tzinfo=utc)
-    if hasattr(dt, "timestamp") and callable(dt.timestamp):
-        return dt.replace(tzinfo=utc).timestamp()
-    return (dt - datetime(1970, 1, 1, tzinfo=utc)).total_seconds()

--- a/tests/consumer/test_oauth1.py
+++ b/tests/consumer/test_oauth1.py
@@ -1,7 +1,4 @@
-try:
-    from urllib.parse import quote_plus
-except ImportError:
-    from urllib import quote_plus
+from urllib.parse import quote_plus
 import pytest
 from unittest import mock
 import responses

--- a/tests/consumer/test_oauth2.py
+++ b/tests/consumer/test_oauth2.py
@@ -2,11 +2,7 @@ import json
 import re
 from oauthlib.oauth2 import MissingCodeError
 
-try:
-    from urllib.parse import quote_plus, parse_qsl
-except ImportError:
-    from urllib import quote_plus
-    from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 import pytest
 from unittest import mock
 import responses


### PR DESCRIPTION
We haven't officially supported Python 2 in awhile. These imports for Python 2 need to go.