### PR TITLE
Made fixes to extend compatibility untill Flask 2.3.0

### DIFF
--- a/flask_dance/contrib/atlassian.py
+++ b/flask_dance/contrib/atlassian.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"
 

--- a/flask_dance/contrib/authentiq.py
+++ b/flask_dance/contrib/authentiq.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Pieter Ennes <support@authentiq.com>"
 

--- a/flask_dance/contrib/azure.py
+++ b/flask_dance/contrib/azure.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Steven MARTINS <steven.martins.fr@gmail.com>"
 

--- a/flask_dance/contrib/digitalocean.py
+++ b/flask_dance/contrib/digitalocean.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Michael Abrahamsen <support@conveyor.dev>"
 

--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Michael Delpech <michaeldel@protonmail.com>"
 

--- a/flask_dance/contrib/dropbox.py
+++ b/flask_dance/contrib/dropbox.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/facebook.py
+++ b/flask_dance/contrib/facebook.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Matt Bachmann <bachmann.matt@gmail.com>"
 

--- a/flask_dance/contrib/fitbit.py
+++ b/flask_dance/contrib/fitbit.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Karan Bhatia <karan.bhatia@gmail.com>"
 

--- a/flask_dance/contrib/github.py
+++ b/flask_dance/contrib/github.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -1,10 +1,11 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from flask_dance.consumer.requests import OAuth2Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Justin Georgeson <jgeorgeson@lopht.net>"
 

--- a/flask_dance/contrib/google.py
+++ b/flask_dance/contrib/google.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/heroku.py
+++ b/flask_dance/contrib/heroku.py
@@ -1,10 +1,11 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from flask_dance.consumer.requests import OAuth2Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/jira.py
+++ b/flask_dance/contrib/jira.py
@@ -2,12 +2,13 @@ import os.path
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 from oauthlib.oauth1 import SIGNATURE_RSA
 from urlobject import URLObject
 
 from flask_dance.consumer import OAuth1ConsumerBlueprint
 from flask_dance.consumer.requests import OAuth1Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/linkedin.py
+++ b/flask_dance/contrib/linkedin.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/meetup.py
+++ b/flask_dance/contrib/meetup.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/nylas.py
+++ b/flask_dance/contrib/nylas.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/reddit.py
+++ b/flask_dance/contrib/reddit.py
@@ -1,10 +1,11 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance import __version__ as _flask_dance_version
 from flask_dance.consumer import OAuth2ConsumerBlueprint, OAuth2Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Sergey Storchay <r8@r8.com.ua>"
 

--- a/flask_dance/contrib/salesforce.py
+++ b/flask_dance/contrib/salesforce.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Przemyslaw Kanach <kanach16@gmail.com>"
 

--- a/flask_dance/contrib/slack.py
+++ b/flask_dance/contrib/slack.py
@@ -1,10 +1,11 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 from requests_oauthlib.compliance_fixes.slack import slack_compliance_fix
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/spotify.py
+++ b/flask_dance/contrib/spotify.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Nick DiRienzo <me@nickdirienzo.com>"
 

--- a/flask_dance/contrib/strava.py
+++ b/flask_dance/contrib/strava.py
@@ -2,10 +2,11 @@ from functools import partial
 
 from flask import _app_ctx_stack as stack
 from flask import request
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance import __version__ as _flask_dance_version
 from flask_dance.consumer import OAuth2ConsumerBlueprint, OAuth2Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Jimmy Hedman <jimmy.hedman@gmail.com>"
 

--- a/flask_dance/contrib/twitch.py
+++ b/flask_dance/contrib/twitch.py
@@ -4,10 +4,11 @@ import os
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
 from flask_dance.consumer.requests import OAuth2Session
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Kerry Hatcher <kerry.hatcher@protonmail.com>"
 

--- a/flask_dance/contrib/twitter.py
+++ b/flask_dance/contrib/twitter.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 
 from flask_dance.consumer import OAuth1ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "David Baumgold <david@davidbaumgold.com>"
 

--- a/flask_dance/contrib/zoho.py
+++ b/flask_dance/contrib/zoho.py
@@ -1,11 +1,12 @@
 from functools import partial
 
 from flask import _app_ctx_stack as stack
-from flask.globals import LocalProxy, _lookup_app_object
+from flask.globals import LocalProxy
 from oauthlib.oauth2.rfc6749 import tokens
 from oauthlib.oauth2.rfc6749.clients.web_application import WebApplicationClient
 
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.utils import _lookup_app_object
 
 __maintainer__ = "Ryan Schaffer <schaffer.ry@gmail.com>"
 

--- a/flask_dance/utils.py
+++ b/flask_dance/utils.py
@@ -1,3 +1,4 @@
+from flask.globals import _app_ctx_stack, _no_app_msg
 import functools
 
 
@@ -47,3 +48,13 @@ def getattrd(obj, name, default=sentinel):
         if default is not sentinel:
             return default
         raise
+
+
+def _lookup_app_object(name):
+    """
+        Immitation for `flask.globals._lookup_app_object` which was depreciated Flask>2.2.0
+    """
+    top = _app_ctx_stack.top
+    if top is None:
+        raise RuntimeError(_no_app_msg)
+    return getattr(top, name)


### PR DESCRIPTION
Due to changes from `flask 2.2.0`, `_lookup_app_object` which is commonly used across all contrib modules is now depreciated. So i mimicked `_lookup_app_object` from `flask 2.1.3` in `flask_dance.utils` and changed imports in all contrib modules to import `_lookup_app_object` from `flask_dance.utils` instead