### PR TITLE
Add ORCID OAuth2 provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 `unreleased`_
 -------------
-nothing yet
+* Added ORCID and ORCID sandbox provider
 
 `6.1.1`_ (2022-08-22)
 ---------------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -215,6 +215,18 @@ OpenStreetMap
     already has the OpenStreetMap authentication token loaded (assuming that the user
     has authenticated with OpenStreetMap at some point in the past).
 
+ORCID
+-------------
+.. module:: flask_dance.contrib.orcid
+
+.. autofunction:: make_orcid_blueprint
+
+.. data:: orcid
+
+    A :class:`~werkzeug.local.LocalProxy` to a :class:`requests.Session` that
+    already has the ORCID (or sandbox ORCID) authentication token loaded (assuming 
+    that the user has authenticated with ORCID at some point in the past).
+
 Reddit
 ------
 .. module:: flask_dance.contrib.reddit

--- a/flask_dance/contrib/orcid.py
+++ b/flask_dance/contrib/orcid.py
@@ -1,0 +1,93 @@
+from flask import g
+from werkzeug.local import LocalProxy
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+
+__maintainer__ = "Matthew Evans <git@ml-evs.science>"
+
+
+def make_orcid_blueprint(
+    client_id=None,
+    client_secret=None,
+    *,
+    scope=None,
+    redirect_url=None,
+    redirect_to=None,
+    login_url=None,
+    authorized_url=None,
+    session_class=None,
+    storage=None,
+    rule_kwargs=None,
+    use_orcid_sandbox=False,
+):
+    """
+    Make a blueprint for authenticating with ORCID (https://orcid.org)
+    using OAuth2.
+
+    This requires a client ID and client secret from ORCID. You should
+    either pass them to this constructor, or make sure that your Flask
+    application config defines them, using the variables
+    :envvar:`ORCID_OAUTH_CLIENT_ID` and :envvar:`ORCID_OAUTH_CLIENT_SECRET`.
+
+    The ORCID Sandbox API (https://sandbox.orcid.org) will be used if
+    the ``use_orcid_sandbox`` argument is set to true.
+
+    Args:
+        client_id (str): The client ID for your application on ORCID.
+        client_secret (str): The client secret for your application on ORCID
+        scope (str, optional): comma-separated list of scopes for the OAuth token
+        redirect_url (str): the URL to redirect to after the authentication
+            dance is complete
+        redirect_to (str): if ``redirect_url`` is not defined, the name of the
+            view to redirect to after the authentication dance is complete.
+            The actual URL will be determined by :func:`flask.url_for`
+        login_url (str, optional): the URL path for the ``login`` view.
+            Defaults to ``/orcid``
+        authorized_url (str, optional): the URL path for the ``authorized`` view.
+            Defaults to ``/orcid/authorized``.
+        session_class (class, optional): The class to use for creating a
+            Requests session. Defaults to
+            :class:`~flask_dance.consumer.requests.OAuth2Session`.
+        storage: A token storage class, or an instance of a token storage
+                class, to use for this blueprint. Defaults to
+                :class:`~flask_dance.consumer.storage.session.SessionStorage`.
+        rule_kwargs (dict, optional): Additional arguments that should be passed when adding
+            the login and authorized routes. Defaults to ``None``.
+        use_orcid_sandbox (bool): Whether to use the ORCID sandbox instead of the production API.
+
+    :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
+    :returns: A :doc:`blueprint <flask:blueprints>` to attach to your Flask app.
+    """
+
+    base_url = "https://api.orcid.org"
+    if use_orcid_sandbox:
+        base_url = "https://api.sandbox.orcid.org"
+
+    orcid_bp = OAuth2ConsumerBlueprint(
+        "orcid",
+        __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        scope=scope,
+        base_url=base_url,
+        authorization_url="https://orcid.org/oauth/authorize",
+        token_url="https://orcid.org//oauth/token",
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        login_url=login_url,
+        authorized_url=authorized_url,
+        session_class=session_class,
+        storage=storage,
+        rule_kwargs=rule_kwargs,
+    )
+    orcid_bp.from_config["client_id"] = "ORCID_OAUTH_CLIENT_ID"
+    orcid_bp.from_config["client_secret"] = "ORCID_OAUTH_CLIENT_SECRET"
+
+    @orcid_bp.before_app_request
+    def set_applocal_session():
+        g.flask_dance_orcid = orcid_bp.session
+
+    return orcid_bp
+
+
+orcid = LocalProxy(lambda: g.flask_dance_orcid)

--- a/flask_dance/contrib/orcid.py
+++ b/flask_dance/contrib/orcid.py
@@ -18,7 +18,7 @@ def make_orcid_blueprint(
     session_class=None,
     storage=None,
     rule_kwargs=None,
-    use_orcid_sandbox=False,
+    sandbox=False,
 ):
     """
     Make a blueprint for authenticating with ORCID (https://orcid.org)
@@ -30,7 +30,7 @@ def make_orcid_blueprint(
     :envvar:`ORCID_OAUTH_CLIENT_ID` and :envvar:`ORCID_OAUTH_CLIENT_SECRET`.
 
     The ORCID Sandbox API (https://sandbox.orcid.org) will be used if
-    the ``use_orcid_sandbox`` argument is set to true.
+    the ``sandbox`` argument is set to true.
 
     Args:
         client_id (str): The client ID for your application on ORCID.
@@ -53,7 +53,7 @@ def make_orcid_blueprint(
                 :class:`~flask_dance.consumer.storage.session.SessionStorage`.
         rule_kwargs (dict, optional): Additional arguments that should be passed when adding
             the login and authorized routes. Defaults to ``None``.
-        use_orcid_sandbox (bool): Whether to use the ORCID sandbox instead of the production API.
+        sandbox (bool): Whether to use the ORCID sandbox instead of the production API.
 
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :doc:`blueprint <flask:blueprints>` to attach to your Flask app.
@@ -62,7 +62,7 @@ def make_orcid_blueprint(
     base_url = "https://api.orcid.org"
     authorization_url = "https://orcid.org/oauth/authorize"
     token_url = "https://orcid.org/oauth/token"
-    if use_orcid_sandbox:
+    if sandbox:
         base_url = "https://api.sandbox.orcid.org"
         authorization_url = "https://sandbox.orcid.org/oauth/authorize"
         token_url = "https://sandbox.orcid.org/oauth/token"

--- a/flask_dance/contrib/orcid.py
+++ b/flask_dance/contrib/orcid.py
@@ -60,8 +60,12 @@ def make_orcid_blueprint(
     """
 
     base_url = "https://api.orcid.org"
+    authorization_url = "https://orcid.org/oauth/authorize"
+    token_url = "https://orcid.org/oauth/token"
     if use_orcid_sandbox:
         base_url = "https://api.sandbox.orcid.org"
+        authorization_url = "https://sandbox.orcid.org/oauth/authorize"
+        token_url = "https://sandbox.orcid.org/oauth/token"
 
     orcid_bp = OAuth2ConsumerBlueprint(
         "orcid",
@@ -70,8 +74,8 @@ def make_orcid_blueprint(
         client_secret=client_secret,
         scope=scope,
         base_url=base_url,
-        authorization_url="https://orcid.org/oauth/authorize",
-        token_url="https://orcid.org/oauth/token",
+        authorization_url=authorization_url,
+        token_url=token_url,
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/flask_dance/contrib/orcid.py
+++ b/flask_dance/contrib/orcid.py
@@ -71,7 +71,7 @@ def make_orcid_blueprint(
         scope=scope,
         base_url=base_url,
         authorization_url="https://orcid.org/oauth/authorize",
-        token_url="https://orcid.org//oauth/token",
+        token_url="https://orcid.org/oauth/token",
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/tests/contrib/test_orcid.py
+++ b/tests/contrib/test_orcid.py
@@ -41,7 +41,7 @@ def test_sandbox_blueprint_factory():
         client_secret="bar",
         scope="user:email",
         redirect_to="index",
-        use_orcid_sandbox=True,
+        sandbox=True,
     )
     assert isinstance(orcid_bp, OAuth2ConsumerBlueprint)
     assert orcid_bp.session.scope == "user:email"

--- a/tests/contrib/test_orcid.py
+++ b/tests/contrib/test_orcid.py
@@ -35,7 +35,7 @@ def test_blueprint_factory():
     assert orcid_bp.token_url == "https://orcid.org/oauth2/token"
 
 
-def test_blueprint_factory():
+def test_sandbox_blueprint_factory():
     orcid_bp = make_orcid_blueprint(
         client_id="foo",
         client_secret="bar",

--- a/tests/contrib/test_orcid.py
+++ b/tests/contrib/test_orcid.py
@@ -1,0 +1,101 @@
+import pytest
+import responses
+from flask import Flask
+from urlobject import URLObject
+
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+from flask_dance.consumer.storage import MemoryStorage
+from flask_dance.contrib.orcid import make_orcid_blueprint, orcid
+
+
+@pytest.fixture
+def make_app():
+    "A callable to create a Flask app with the ORCID provider"
+
+    def _make_app(*args, **kwargs):
+        app = Flask(__name__)
+        app.secret_key = "whatever"
+        blueprint = make_orcid_blueprint(*args, **kwargs)
+        app.register_blueprint(blueprint)
+        return app
+
+    return _make_app
+
+
+def test_blueprint_factory():
+    orcid_bp = make_orcid_blueprint(
+        client_id="foo", client_secret="bar", scope="user:email", redirect_to="index"
+    )
+    assert isinstance(orcid_bp, OAuth2ConsumerBlueprint)
+    assert orcid_bp.session.scope == "user:email"
+    assert orcid_bp.session.base_url == "https://api.orcid.org"
+    assert orcid_bp.session.client_id == "foo"
+    assert orcid_bp.client_secret == "bar"
+    assert orcid_bp.authorization_url == "https://orcid.org/oauth2/authorize"
+    assert orcid_bp.token_url == "https://orcid.org/oauth2/token"
+
+
+def test_blueprint_factory():
+    orcid_bp = make_orcid_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope="user:email",
+        redirect_to="index",
+        sandbox=True,
+    )
+    assert isinstance(orcid_bp, OAuth2ConsumerBlueprint)
+    assert orcid_bp.session.scope == "user:email"
+    assert orcid_bp.session.base_url == "https://api.sandbox.orcid.org"
+    assert orcid_bp.session.client_id == "foo"
+    assert orcid_bp.client_secret == "bar"
+    assert orcid_bp.authorization_url == "https://sandbox.orcid.org/oauth2/authorize"
+    assert orcid_bp.token_url == "https://sandbox.orcid.org/oauth2/token"
+
+
+def test_load_from_config(make_app):
+    app = make_app()
+    app.config["ORCID_OAUTH_CLIENT_ID"] = "foo"
+    app.config["ORCID_OAUTH_CLIENT_SECRET"] = "bar"
+
+    resp = app.test_client().get("/orcid")
+    url = resp.headers["Location"]
+    client_id = URLObject(url).query.dict.get("client_id")
+    assert client_id == "foo"
+
+
+@responses.activate
+def test_context_local(make_app):
+    responses.add(responses.GET, "https://google.com")
+
+    # set up two apps with two different set of auth tokens
+    app1 = make_app(
+        "foo1",
+        "bar1",
+        redirect_to="url1",
+        storage=MemoryStorage({"access_token": "app1"}),
+    )
+    app2 = make_app(
+        "foo2",
+        "bar2",
+        redirect_to="url2",
+        storage=MemoryStorage({"access_token": "app2"}),
+    )
+
+    # outside of a request context, referencing functions on the `orcid` object
+    # will raise an exception
+    with pytest.raises(RuntimeError):
+        orcid.get("https://google.com")
+
+    # inside of a request context, `orcid` should be a proxy to the correct
+    # blueprint session
+    with app1.test_request_context("/"):
+        app1.preprocess_request()
+        orcid.get("https://google.com")
+        request = responses.calls[0].request
+        assert request.headers["Authorization"] == "Bearer app1"
+
+    with app2.test_request_context("/"):
+        app2.preprocess_request()
+        orcid.get("https://google.com")
+        request = responses.calls[1].request
+        assert request.headers["Authorization"] == "Bearer app2"

--- a/tests/contrib/test_orcid.py
+++ b/tests/contrib/test_orcid.py
@@ -31,8 +31,8 @@ def test_blueprint_factory():
     assert orcid_bp.session.base_url == "https://api.orcid.org"
     assert orcid_bp.session.client_id == "foo"
     assert orcid_bp.client_secret == "bar"
-    assert orcid_bp.authorization_url == "https://orcid.org/oauth2/authorize"
-    assert orcid_bp.token_url == "https://orcid.org/oauth2/token"
+    assert orcid_bp.authorization_url == "https://orcid.org/oauth/authorize"
+    assert orcid_bp.token_url == "https://orcid.org/oauth/token"
 
 
 def test_sandbox_blueprint_factory():
@@ -41,15 +41,15 @@ def test_sandbox_blueprint_factory():
         client_secret="bar",
         scope="user:email",
         redirect_to="index",
-        sandbox=True,
+        use_orcid_sandbox=True,
     )
     assert isinstance(orcid_bp, OAuth2ConsumerBlueprint)
     assert orcid_bp.session.scope == "user:email"
     assert orcid_bp.session.base_url == "https://api.sandbox.orcid.org"
     assert orcid_bp.session.client_id == "foo"
     assert orcid_bp.client_secret == "bar"
-    assert orcid_bp.authorization_url == "https://sandbox.orcid.org/oauth2/authorize"
-    assert orcid_bp.token_url == "https://sandbox.orcid.org/oauth2/token"
+    assert orcid_bp.authorization_url == "https://sandbox.orcid.org/oauth/authorize"
+    assert orcid_bp.token_url == "https://sandbox.orcid.org/oauth/token"
 
 
 def test_load_from_config(make_app):


### PR DESCRIPTION
This PR adds support for ORCID (https://orcid.org/) and its sandbox server (https://sandbox.orcid.org) via a blueprint init option `use_orcid_sandbox`.

It is slightly tricky to test this as OAuth configs at ORCID require human intervention at ORCID's end, and even then, the ORCID sandbox does not allow non-HTTPS callback URIs (like localhost). I was able to use this code to authorize via the ORCID sandbox by monkey-patching the authorized URL in the base blueprint to point at [Google's OAuth playground](https://developers.google.com/oauthplayground/)  using the `openid` scope (might be useful if this was easier to do).

Thanks for flask-dance!