### PR TITLE
account for overrides when generating new token

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 `unreleased`_
 -------------
-nothing yet
+* Added support for auto refreshing tokens if the OAuth model is overriden as in the multi-provider example
 
 `7.0.0`_ (2023-05-10)
 ---------------------

--- a/flask_dance/consumer/storage/sqla.py
+++ b/flask_dance/consumer/storage/sqla.py
@@ -214,6 +214,7 @@ class SQLAlchemyStorage(BaseStorage):
         has_user = hasattr(self.model, "user")
         if has_user and u:
             existing_query = existing_query.filter_by(user=u)
+
         # queue up delete query -- won't be run until commit()
         existing_query.delete()
         # create a new model for this token
@@ -222,6 +223,20 @@ class SQLAlchemyStorage(BaseStorage):
             kwargs["user_id"] = uid
         if has_user and u:
             kwargs["user"] = u
+
+        existing = existing_query.first()
+
+        # if the oauth model is overridden, make sure to copy the columns
+        column_names = [
+            col.name
+            for col in self.model.__table__.columns
+            if not col.nullable
+            and not col.primary_key
+            and col.name not in kwargs.keys()
+        ]
+        for name in column_names:
+            kwargs[name] = getattr(existing, name)
+
         self.session.add(self.model(**kwargs))
         # commit to delete and add simultaneously
         self.session.commit()

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -748,10 +748,6 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
     }
 
 
-# def test_sqla_overwrite_token_override_model(app, db, blueprint, request):
-#     class OAuth(OAuthConsumerMixin, db.Model):
-
-
 def test_sqla_cache(app, db, blueprint, request):
     cache = Cache(app)
 

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -379,7 +379,7 @@ def test_sqla_flask_login(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 5
+    assert len(queries) == 6
 
     # check the database
     authorizations = OAuth.query.all()

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -692,6 +692,7 @@ def test_sqla_delete_token(app, db, blueprint, request):
 
 def test_sqla_overwrite_token(app, db, blueprint, request):
     class OAuth(OAuthConsumerMixin, db.Model):
+
         pass
 
     blueprint.storage = SQLAlchemyStorage(OAuth, db.session)
@@ -708,6 +709,8 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
     existing = OAuth(
         provider="test-service",
         token={"access_token": "something", "token_type": "bearer", "scope": ["blah"]},
+        provider_user_id="some-hash",
+        provider_user_login = "user.name"
     )
     db.session.add(existing)
     db.session.commit()
@@ -743,6 +746,10 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
         "token_type": "bearer",
         "scope": [""],
     }
+
+
+# def test_sqla_overwrite_token_override_model(app, db, blueprint, request):
+#     class OAuth(OAuthConsumerMixin, db.Model):
 
 
 def test_sqla_cache(app, db, blueprint, request):

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -351,7 +351,7 @@ def test_sqla_flask_login(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 6
+    assert len(queries) == 5
 
     # lets do it again, with Bob as the logged in user -- he gets a different token
     if "_login_user" in flask.g:
@@ -692,8 +692,8 @@ def test_sqla_delete_token(app, db, blueprint, request):
 
 def test_sqla_overwrite_token(app, db, blueprint, request):
     class OAuth(OAuthConsumerMixin, db.Model):
-        provider_user_id=db.Column(db.String, nullable=False)
-        provider_user_login=db.Column(db.String, nullable=False)
+        provider_user_id = db.Column(db.String, nullable=False)
+        provider_user_login = db.Column(db.String, nullable=False)
 
     blueprint.storage = SQLAlchemyStorage(OAuth, db.session)
 
@@ -710,7 +710,7 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
         provider="test-service",
         token={"access_token": "something", "token_type": "bearer", "scope": ["blah"]},
         provider_user_id="some-hash",
-        provider_user_login = "user.name"
+        provider_user_login="user.name",
     )
     db.session.add(existing)
     db.session.commit()

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -692,8 +692,8 @@ def test_sqla_delete_token(app, db, blueprint, request):
 
 def test_sqla_overwrite_token(app, db, blueprint, request):
     class OAuth(OAuthConsumerMixin, db.Model):
-
-        pass
+        provider_user_id=db.Column(db.String, nullable=False)
+        provider_user_login=db.Column(db.String, nullable=False)
 
     blueprint.storage = SQLAlchemyStorage(OAuth, db.session)
 
@@ -733,7 +733,7 @@ def test_sqla_overwrite_token(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 2
+    assert len(queries) == 3
 
     # check that the database record was overwritten
     authorizations = OAuth.query.all()

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -128,7 +128,7 @@ def test_sqla_storage_without_user(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 2
+    assert len(queries) == 3
 
     # check the database
     authorizations = OAuth.query.all()
@@ -211,7 +211,7 @@ def test_sqla_storage(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 3
+    assert len(queries) == 4
 
     # check the database
     alice = User.query.first()
@@ -351,7 +351,7 @@ def test_sqla_flask_login(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 5
+    assert len(queries) == 6
 
     # lets do it again, with Bob as the logged in user -- he gets a different token
     if "_login_user" in flask.g:
@@ -519,7 +519,7 @@ def test_sqla_flask_login_anon_to_authed(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 5
+    assert len(queries) == 6
 
     # check the database
     users = User.query.all()
@@ -781,7 +781,7 @@ def test_sqla_cache(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 2
+    assert len(queries) == 3
 
     expected_token = {"access_token": "foobar", "token_type": "bearer", "scope": [""]}
 

--- a/tests/consumer/storage/test_sqla.py
+++ b/tests/consumer/storage/test_sqla.py
@@ -351,7 +351,7 @@ def test_sqla_flask_login(app, db, blueprint, request):
                 "/oauth_done",
             )
 
-    assert len(queries) == 5
+    assert len(queries) == 6
 
     # lets do it again, with Bob as the logged in user -- he gets a different token
     if "_login_user" in flask.g:


### PR DESCRIPTION
If the user has overridden the OAuth model, the automatic token refresh will fail if the user has defined columns that are not nullable.  The common use case for this seems to be the instance where the author has associations with multiple providers.  The commit will fail because the provider_user_id and the provider_username are not carried over to the new token.

The proposed solution will end up added an additional query to get the existing entry and copying over any fields that are not nullable into the new token.  