### PR TITLE
Enable token refresh for Gitlab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 `unreleased`_
 -------------
-nothing yet
+* Added auto refresh support for Gitlab
 
 `7.0.0`_ (2023-05-10)
 ---------------------

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -40,7 +40,7 @@ def make_gitlab_blueprint(
         client_id (str): The client ID for your application on GitLab.
         client_secret (str): The client secret for your application on GitLab
         scope (str, optional): comma-separated list of scopes for the OAuth token
-        refresh (bool): Whether this instance of Gitlab supports token refreshes.
+        refresh (bool): Whether this instance of `Gitlab` supports token refreshes.
             `Refresh opt out was removed in Gitlab 15.0
             <https://docs.gitlab.com/ee/integration/oauth_provider.html#access-token-expiration>`
         redirect_url (str): the URL to redirect to after the authentication

--- a/flask_dance/contrib/gitlab.py
+++ b/flask_dance/contrib/gitlab.py
@@ -18,6 +18,7 @@ def make_gitlab_blueprint(
     client_secret=None,
     *,
     scope=None,
+    refresh=False,
     redirect_url=None,
     redirect_to=None,
     login_url=None,
@@ -39,6 +40,9 @@ def make_gitlab_blueprint(
         client_id (str): The client ID for your application on GitLab.
         client_secret (str): The client secret for your application on GitLab
         scope (str, optional): comma-separated list of scopes for the OAuth token
+        refresh (bool): Whether this instance of Gitlab supports token refreshes.
+            `Refresh opt out was removed in Gitlab 15.0
+            <https://docs.gitlab.com/ee/integration/oauth_provider.html#access-token-expiration>`
         redirect_url (str): the URL to redirect to after the authentication
             dance is complete
         redirect_to (str): if ``redirect_url`` is not defined, the name of the
@@ -66,6 +70,8 @@ def make_gitlab_blueprint(
     :rtype: :class:`~flask_dance.consumer.OAuth2ConsumerBlueprint`
     :returns: A :doc:`blueprint <flask:blueprints>` to attach to your Flask app.
     """
+    auto_refresh_url = None
+
     if not verify_tls_certificates:
         if session_class:
             raise ValueError(
@@ -73,6 +79,9 @@ def make_gitlab_blueprint(
             )
         else:
             session_class = NoVerifyOAuth2Session
+
+    if refresh:
+        auto_refresh_url = f"https://{hostname}/oauth/token"
 
     gitlab_bp = OAuth2ConsumerBlueprint(
         "gitlab",
@@ -83,6 +92,7 @@ def make_gitlab_blueprint(
         base_url=f"https://{hostname}/api/v4/",
         authorization_url=f"https://{hostname}/oauth/authorize",
         token_url=f"https://{hostname}/oauth/token",
+        auto_refresh_url=auto_refresh_url,
         redirect_url=redirect_url,
         redirect_to=redirect_to,
         login_url=login_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
     "sqlalchemy>=1.3.11",
     "pytest",
     "betamax",
+    "pillow<=9.5"
 ]
 sqla = ["sqlalchemy>=1.3.11"]
 signals = ["blinker"]

--- a/tests/contrib/test_gitlab.py
+++ b/tests/contrib/test_gitlab.py
@@ -165,8 +165,12 @@ def test_no_verify_api_call(make_app, mocker):
 
 def test_blueprint_factory_refresh():
     glbp = make_gitlab_blueprint(
-        client_id="foo", client_secret="bar", scope="read_user", hostname="my-instance.com", redirect_to="index",
-        refresh=True
+        client_id="foo",
+        client_secret="bar",
+        scope="read_user",
+        hostname="my-instance.com",
+        redirect_to="index",
+        refresh=True,
     )
 
     assert glbp.auto_refresh_url == "https://my-instance.com/oauth/token"

--- a/tests/contrib/test_gitlab.py
+++ b/tests/contrib/test_gitlab.py
@@ -161,3 +161,12 @@ def test_no_verify_api_call(make_app, mocker):
         mock_on_request.assert_called()
         call_verify = mock_on_request.call_args[1].get("verify", True)
         assert call_verify is False
+
+
+def test_blueprint_factory_refresh():
+    glbp = make_gitlab_blueprint(
+        client_id="foo", client_secret="bar", scope="read_user", hostname="my-instance.com", redirect_to="index",
+        refresh=True
+    )
+
+    assert glbp.auto_refresh_url == "https://my-instance.com/oauth/token"


### PR DESCRIPTION
Gitlab removed support for optionally expiring tokens in Gitlab 15.0.  Adding in the refresh as optional since there may be self hosted instances in the wild older then 15.0.

https://docs.gitlab.com/ee/integration/oauth_provider.html#access-token-expiration