### PR TITLE
fix Discord prompt parameter

### DIFF
--- a/flask_dance/contrib/discord.py
+++ b/flask_dance/contrib/discord.py
@@ -58,7 +58,7 @@ def make_discord_blueprint(
     scope = scope or ["identify"]
     authorization_url_params = {"prompt": "consent"}
     if prompt is None:
-        authorization_url_params["prompt"] = None
+        authorization_url_params["prompt"] = "none"
     discord_bp = OAuth2ConsumerBlueprint(
         "discord",
         __name__,

--- a/tests/contrib/test_discord.py
+++ b/tests/contrib/test_discord.py
@@ -74,6 +74,7 @@ def test_blueprint_factory_with_prompt_None():
     assert discord_bp.token_url == "https://discord.com/api/oauth2/token"
     assert discord_bp.authorization_url_params["prompt"] == "none"
 
+
 def test_load_from_config(make_app):
     app = make_app(redirect_to="index")
     app.config["DISCORD_OAUTH_CLIENT_ID"] = "foo"

--- a/tests/contrib/test_discord.py
+++ b/tests/contrib/test_discord.py
@@ -39,7 +39,25 @@ def test_blueprint_factory():
     assert discord_bp.authorization_url_params["prompt"] == "consent"
 
 
-def test_blueprint_factory_with_prompt():
+def test_blueprint_factory_with_prompt_consent():
+    discord_bp = make_discord_blueprint(
+        client_id="foo",
+        client_secret="bar",
+        scope=["identify", "email"],
+        redirect_to="index",
+        prompt="consent",
+    )
+    assert isinstance(discord_bp, OAuth2ConsumerBlueprint)
+    assert discord_bp.session.scope == ["identify", "email"]
+    assert discord_bp.session.base_url == "https://discord.com/"
+    assert discord_bp.session.client_id == "foo"
+    assert discord_bp.client_secret == "bar"
+    assert discord_bp.authorization_url == "https://discord.com/api/oauth2/authorize"
+    assert discord_bp.token_url == "https://discord.com/api/oauth2/token"
+    assert discord_bp.authorization_url_params["prompt"] == "consent"
+
+
+def test_blueprint_factory_with_prompt_None():
     discord_bp = make_discord_blueprint(
         client_id="foo",
         client_secret="bar",
@@ -54,8 +72,7 @@ def test_blueprint_factory_with_prompt():
     assert discord_bp.client_secret == "bar"
     assert discord_bp.authorization_url == "https://discord.com/api/oauth2/authorize"
     assert discord_bp.token_url == "https://discord.com/api/oauth2/token"
-    assert discord_bp.authorization_url_params["prompt"] == None
-
+    assert discord_bp.authorization_url_params["prompt"] == "none"
 
 def test_load_from_config(make_app):
     app = make_app(redirect_to="index")


### PR DESCRIPTION
the [Discord authentication url](https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-authorization-url-example) expects the prompt argument to be "consent" or "none", by default "consent". If set as `None` in the blueprint constructor, it remains `None` until it is passed to the url, where it is left off entirely. Changing it to `"none"` fixes the issue without the possibility of breaking any other providers.

It looks like this is the only provider with this kind of issue.